### PR TITLE
Feature/notebook ergonomics workspace bootstrap

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: read
 
+# Actions pinned for supply-chain hardening:
+# actions/checkout@v4 -> 34e114876b0b11c390a56381ad16ebd13914f8d5
+# actions/setup-python@v5 -> a26af69be951a213d495a4c3e4e4022e16d87065
+# actions/upload-artifact@v4 -> ea165f8d65b6e75b540449e92b4886f43607fa02
+# actions/download-artifact@v4 -> d3f86a106a0bac45b974a628896c90dbdf5c8093
+# pypa/gh-action-pypi-publish@release/v1 -> cef221092ed1bacb1cc03d23a2d87d1d172e277b
+
 jobs:
   build:
     name: Build distribution artifacts
@@ -16,10 +23,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -33,7 +40,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload built distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: python-distributions
           path: dist/*
@@ -50,12 +57,12 @@ jobs:
 
     steps:
       - name: Download built distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: python-distributions
           path: dist
 
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ operational runs.
 Start with:
 
 * [docs/notebook_integration.md](docs/notebook_integration.md)
+* [docs/notebook_workspace_bootstrap.md](docs/notebook_workspace_bootstrap.md)
 * [docs/notebook_execution_api.md](docs/notebook_execution_api.md)
 * [docs/pipeline_integration.md](docs/pipeline_integration.md)
 * [docs/concurrency_and_idempotency.md](docs/concurrency_and_idempotency.md)

--- a/README.md
+++ b/README.md
@@ -323,8 +323,8 @@ remain supported by `.github/workflows/milestone_validation.yml`.
 Package version and milestone release tags are intentionally separate. The
 package version in `pyproject.toml` is Python distribution metadata for editable
 installs, local wheel/sdist validation, and package import metadata. It remains
-`0.1.0` until the package distribution semantics themselves need a version
-change. Milestone release tags identify repository release snapshots and
+the value declared in `pyproject.toml` until the package distribution semantics
+themselves need a version change. Milestone release tags identify repository release snapshots and
 validation evidence, for example
 `v0.36.0-scalable-evidence-interoperability-release-hardening`; they appear in
 GitHub Release tags, release notes, and release checklists, but they do not

--- a/docs/m36_release_notes.md
+++ b/docs/m36_release_notes.md
@@ -140,6 +140,8 @@ Current workflow action inventory:
 | `actions/checkout` | GitHub-maintained | `34e114876b0b11c390a56381ad16ebd13914f8d5` | `v4` |
 | `actions/setup-python` | GitHub-maintained | `a26af69be951a213d495a4c3e4e4022e16d87065` | `v5` |
 | `actions/upload-artifact` | GitHub-maintained | `ea165f8d65b6e75b540449e92b4886f43607fa02` | `v4` |
+| `actions/download-artifact` | GitHub-maintained | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | `v4` |
+| `pypa/gh-action-pypi-publish` | Third-party | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` | `release/v1` |
 | `softprops/action-gh-release` | Third-party | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | `v2` |
 
 There are no local reusable actions in the current workflow set. There are no

--- a/docs/m36_release_validation_checklist.md
+++ b/docs/m36_release_validation_checklist.md
@@ -64,6 +64,8 @@ Current reviewed pins:
 - `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5`
 - `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065`
 - `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02`
+- `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093`
+- `pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b`
 - `softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`
 
 When refreshing a pin:

--- a/docs/notebook_integration.md
+++ b/docs/notebook_integration.md
@@ -25,6 +25,24 @@ benchmark-pack, campaign, validation, regime, or stress-test behavior. They
 should remain thin cells that import StratLake APIs, pass explicit inputs, and
 inspect canonical outputs.
 
+## Local Notebook Workspace Bootstrap
+
+Use the installed bootstrap command to initialize a local notebook workspace
+under an explicit root path:
+
+```powershell
+stratlake-init-notebook --root ./stratlake-notebooks
+```
+
+This creates local `notebooks/`, `configs/`, `docs/`, `contracts/`, and
+`artifacts/` directories, copies a curated starter allowlist from repository
+`configs/` and `docs/`, and skips existing files by default. Use `--force` to
+overwrite copied starter templates only.
+
+See [`docs/notebook_workspace_bootstrap.md`](notebook_workspace_bootstrap.md)
+for command reference, installed CLI entry points, and package/workspace
+boundary guidance.
+
 ## Existing Notebook Surface
 
 The public notebook-friendly execution surface is documented in

--- a/docs/notebook_workspace_bootstrap.md
+++ b/docs/notebook_workspace_bootstrap.md
@@ -1,0 +1,120 @@
+# Notebook Workspace Bootstrap
+
+## Purpose
+
+`stratlake-init-notebook` initializes a local notebook workspace under an explicit root.
+It copies curated starter config and guidance files while keeping mutable workspace state local.
+
+This improves notebook-first and pip-installed workflows by removing repository-root assumptions.
+
+## Install And Run
+
+Editable install from a repository checkout:
+
+```powershell
+python -m pip install -e .
+```
+
+Optional dev extras:
+
+```powershell
+python -m pip install -e ".[dev]"
+```
+
+Bootstrap a workspace in the current directory:
+
+```powershell
+stratlake-init-notebook
+```
+
+Bootstrap a workspace at an explicit root:
+
+```powershell
+stratlake-init-notebook --root ./stratlake-notebooks
+```
+
+Overwrite only copied starter templates:
+
+```powershell
+stratlake-init-notebook --root ./stratlake-notebooks --force
+```
+
+## What Gets Created
+
+Directory layout under the selected root:
+
+- `notebooks/`
+- `configs/`
+- `docs/`
+- `contracts/`
+- `artifacts/`
+
+Curated starter files are copied from repository `configs/` and `docs/` into the local workspace.
+Existing files are preserved by default.
+
+## Installed Commands
+
+The package now provides stable installed entry points for common workflows:
+
+- `stratlake-init-notebook`
+- `stratlake-run-strategy`
+- `stratlake-run-alpha`
+- `stratlake-run-alpha-evaluation`
+- `stratlake-run-portfolio`
+- `stratlake-run-pipeline`
+- `stratlake-run-research-campaign`
+- `stratlake-run-benchmark-pack`
+- `stratlake-run-candidate-selection`
+- `stratlake-review-candidate-selection`
+- `stratlake-compare-strategies`
+- `stratlake-compare-alpha`
+- `stratlake-validate-config`
+- `stratlake-doctor`
+- `stratlake-explain-config`
+- `stratlake-catalog-index`
+- `stratlake-query-catalog`
+- `stratlake-explore-catalog-evidence`
+- `stratlake-export-catalog-lineage`
+- `stratlake-build-evidence-review`
+- `stratlake-run-promotion-governance-report`
+
+Python module invocations remain compatible, for example:
+
+```powershell
+python -m src.cli.run_strategy --strategy momentum_v1
+```
+
+## Package Versus Workspace Boundaries
+
+Package responsibilities:
+
+- reusable command surfaces
+- reusable library code
+- deterministic execution and validation logic
+
+Workspace responsibilities:
+
+- mutable `configs/` copies
+- mutable local `docs/` copies
+- local `contracts/`
+- local `notebooks/`
+- generated local `artifacts/`
+
+The bootstrap command does not create fake run outputs and does not mutate package files.
+
+## Troubleshooting
+
+`stratlake-init-notebook` reports missing starter templates:
+
+- Install from a repository checkout using editable mode.
+- Confirm `configs/` and `docs/` exist in the installed source tree.
+
+Files were skipped unexpectedly:
+
+- This is expected when destination files already exist.
+- Re-run with `--force` to overwrite copied starter templates only.
+
+Paths looked wrong:
+
+- Always pass an explicit `--root` for notebooks and tutorials.
+- The command refuses to write outside the selected workspace root.

--- a/docs/notebook_workspace_bootstrap.md
+++ b/docs/notebook_workspace_bootstrap.md
@@ -9,6 +9,8 @@ This improves notebook-first and pip-installed workflows by removing repository-
 
 ## Install And Run
 
+Normal wheel/pip installs are supported. Starter templates are bundled as package resources.
+
 Editable install from a repository checkout:
 
 ```powershell
@@ -49,8 +51,10 @@ Directory layout under the selected root:
 - `contracts/`
 - `artifacts/`
 
-Curated starter files are copied from repository `configs/` and `docs/` into the local workspace.
+Curated starter files are copied from bundled package resources into the local workspace.
 Existing files are preserved by default.
+The bundled package-resource templates are only the source for the initial copy. After copying,
+the local workspace files are user-owned and mutable.
 
 ## Installed Commands
 
@@ -101,13 +105,14 @@ Workspace responsibilities:
 - generated local `artifacts/`
 
 The bootstrap command does not create fake run outputs and does not mutate package files.
+It never writes into site-packages.
 
 ## Troubleshooting
 
 `stratlake-init-notebook` reports missing starter templates:
 
-- Install from a repository checkout using editable mode.
-- Confirm `configs/` and `docs/` exist in the installed source tree.
+- Reinstall the package so bundled notebook workspace resources are present.
+- Validate installation with `python -m pip show stratlake-trade-engine` and reinstall from wheel if needed.
 
 Files were skipped unexpectedly:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,29 @@ dev = [
     "ruff",
 ]
 
+[project.scripts]
+stratlake-init-notebook = "src.cli.init_notebook_workspace:main"
+stratlake-run-strategy = "src.cli.run_strategy:main"
+stratlake-run-alpha = "src.cli.run_alpha:main"
+stratlake-run-alpha-evaluation = "src.cli.run_alpha_evaluation:main"
+stratlake-run-portfolio = "src.cli.run_portfolio:main"
+stratlake-run-pipeline = "src.cli.run_pipeline:main"
+stratlake-run-research-campaign = "src.cli.run_research_campaign:main"
+stratlake-run-benchmark-pack = "src.cli.run_benchmark_pack:main"
+stratlake-run-candidate-selection = "src.cli.run_candidate_selection:main"
+stratlake-review-candidate-selection = "src.cli.review_candidate_selection:main"
+stratlake-compare-strategies = "src.cli.compare_strategies:main"
+stratlake-compare-alpha = "src.cli.compare_alpha:main"
+stratlake-validate-config = "src.cli.validate_config:main"
+stratlake-doctor = "src.cli.stratlake_doctor:main"
+stratlake-explain-config = "src.cli.explain_config:main"
+stratlake-catalog-index = "src.cli.catalog_index:main"
+stratlake-query-catalog = "src.cli.query_catalog:main"
+stratlake-explore-catalog-evidence = "src.cli.explore_catalog_evidence:main"
+stratlake-export-catalog-lineage = "src.cli.export_catalog_lineage:main"
+stratlake-build-evidence-review = "src.cli.build_evidence_review:main"
+stratlake-run-promotion-governance-report = "src.cli.run_promotion_governance_report:main"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["src*", "cli*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ stratlake-run-promotion-governance-report = "src.cli.run_promotion_governance_re
 where = ["."]
 include = ["src*", "cli*"]
 
+[tool.setuptools.package-data]
+"src.resources.notebook_workspace" = ["**/*"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/cli/init_notebook_workspace.py
+++ b/src/cli/init_notebook_workspace.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+from typing import Sequence
+
+STARTER_CONFIGS: tuple[str, ...] = (
+    "features.yml",
+    "strategies.yml",
+    "evaluation.yml",
+    "execution.yml",
+    "portfolios.yml",
+    "candidate_selection.yml",
+    "review.yml",
+    "profiles/notebook.yml",
+    "pipelines/scenario_matrix_pipeline.yml",
+)
+
+STARTER_DOCS: tuple[str, ...] = (
+    "getting_started.md",
+    "notebook_integration.md",
+    "notebook_execution_api.md",
+    "pipeline_integration.md",
+    "concurrency_and_idempotency.md",
+    "cross_layer_validation.md",
+    "catalog_notebook_ergonomics.md",
+    "examples/notebook_execution_api_examples.py",
+)
+
+WORKSPACE_DIRS: tuple[str, ...] = ("notebooks", "configs", "docs", "contracts", "artifacts")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Initialize a local StratLake notebook workspace with starter configs, docs, and "
+            "workspace directories."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Target workspace root directory. Defaults to the current working directory.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite copied starter templates if they already exist.",
+    )
+    return parser.parse_args(argv)
+
+
+def run_cli(argv: Sequence[str] | None = None) -> dict[str, object]:
+    args = parse_args(argv)
+    summary = initialize_notebook_workspace(Path(args.root), force=args.force)
+    print_summary(summary)
+    return summary
+
+
+def initialize_notebook_workspace(root: Path, *, force: bool = False) -> dict[str, object]:
+    workspace_root = root.expanduser().resolve()
+    source_root = _resolve_source_root()
+
+    before_exists = workspace_root.exists()
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    created_dirs: list[str] = []
+    existing_dirs: list[str] = []
+    for relative in WORKSPACE_DIRS:
+        destination = _destination_path(workspace_root, relative)
+        if destination.exists():
+            existing_dirs.append(relative)
+        else:
+            destination.mkdir(parents=True, exist_ok=True)
+            created_dirs.append(relative)
+
+    copied: list[str] = []
+    overwritten: list[str] = []
+    skipped: list[str] = []
+
+    copied_configs, overwritten_configs, skipped_configs = _copy_starters(
+        workspace_root=workspace_root,
+        source_root=source_root,
+        source_folder="configs",
+        destination_folder="configs",
+        allowlist=STARTER_CONFIGS,
+        force=force,
+    )
+    copied.extend(copied_configs)
+    overwritten.extend(overwritten_configs)
+    skipped.extend(skipped_configs)
+
+    copied_docs, overwritten_docs, skipped_docs = _copy_starters(
+        workspace_root=workspace_root,
+        source_root=source_root,
+        source_folder="docs",
+        destination_folder="docs",
+        allowlist=STARTER_DOCS,
+        force=force,
+    )
+    copied.extend(copied_docs)
+    overwritten.extend(overwritten_docs)
+    skipped.extend(skipped_docs)
+
+    return {
+        "root": workspace_root.as_posix(),
+        "workspace_preexisting": before_exists,
+        "created_dirs": created_dirs,
+        "existing_dirs": existing_dirs,
+        "copied": copied,
+        "overwritten": overwritten,
+        "skipped": skipped,
+        "force": force,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        run_cli(argv)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def _resolve_source_root() -> Path:
+    source_root = Path(__file__).resolve().parents[2]
+    missing = []
+    if not (source_root / "configs").is_dir():
+        missing.append("configs")
+    if not (source_root / "docs").is_dir():
+        missing.append("docs")
+    if missing:
+        joined = ", ".join(missing)
+        raise RuntimeError(
+            "Notebook starter templates are unavailable in this installation. "
+            f"Missing source directories: {joined}."
+        )
+    return source_root
+
+
+def _copy_starters(
+    *,
+    workspace_root: Path,
+    source_root: Path,
+    source_folder: str,
+    destination_folder: str,
+    allowlist: Sequence[str],
+    force: bool,
+) -> tuple[list[str], list[str], list[str]]:
+    copied: list[str] = []
+    overwritten: list[str] = []
+    skipped: list[str] = []
+
+    for relative in allowlist:
+        source = source_root / source_folder / relative
+        if not source.is_file():
+            raise FileNotFoundError(f"Starter template not found: {source.as_posix()}")
+
+        destination = _destination_path(workspace_root, f"{destination_folder}/{relative}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        if destination.exists() and not force:
+            skipped.append(f"{destination_folder}/{relative}")
+            continue
+
+        if destination.exists() and force:
+            overwritten.append(f"{destination_folder}/{relative}")
+        else:
+            copied.append(f"{destination_folder}/{relative}")
+
+        shutil.copy2(source, destination)
+
+    return copied, overwritten, skipped
+
+
+def _destination_path(workspace_root: Path, relative: str) -> Path:
+    destination = (workspace_root / relative).resolve()
+    if not destination.is_relative_to(workspace_root):
+        raise ValueError(
+            f"Refusing to write outside workspace root: {destination.as_posix()}"
+        )
+    return destination
+
+
+def print_summary(summary: dict[str, object]) -> None:
+    print(f"Initialized StratLake notebook workspace at: {summary['root']}")
+    print(
+        "Directory status: "
+        f"created={len(summary['created_dirs'])}, "
+        f"already_present={len(summary['existing_dirs'])}"
+    )
+    print(
+        "Template status: "
+        f"copied={len(summary['copied'])}, "
+        f"overwritten={len(summary['overwritten'])}, "
+        f"skipped={len(summary['skipped'])}"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/init_notebook_workspace.py
+++ b/src/cli/init_notebook_workspace.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-import shutil
+from importlib import resources
 import sys
 from pathlib import Path
 from typing import Sequence
@@ -30,6 +30,7 @@ STARTER_DOCS: tuple[str, ...] = (
 )
 
 WORKSPACE_DIRS: tuple[str, ...] = ("notebooks", "configs", "docs", "contracts", "artifacts")
+NOTEBOOK_WORKSPACE_RESOURCE_PACKAGE = "src.resources.notebook_workspace"
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -61,7 +62,7 @@ def run_cli(argv: Sequence[str] | None = None) -> dict[str, object]:
 
 def initialize_notebook_workspace(root: Path, *, force: bool = False) -> dict[str, object]:
     workspace_root = root.expanduser().resolve()
-    source_root = _resolve_source_root()
+    resource_root = _resolve_resource_root()
 
     before_exists = workspace_root.exists()
     workspace_root.mkdir(parents=True, exist_ok=True)
@@ -82,7 +83,7 @@ def initialize_notebook_workspace(root: Path, *, force: bool = False) -> dict[st
 
     copied_configs, overwritten_configs, skipped_configs = _copy_starters(
         workspace_root=workspace_root,
-        source_root=source_root,
+        resource_root=resource_root,
         source_folder="configs",
         destination_folder="configs",
         allowlist=STARTER_CONFIGS,
@@ -94,7 +95,7 @@ def initialize_notebook_workspace(root: Path, *, force: bool = False) -> dict[st
 
     copied_docs, overwritten_docs, skipped_docs = _copy_starters(
         workspace_root=workspace_root,
-        source_root=source_root,
+        resource_root=resource_root,
         source_folder="docs",
         destination_folder="docs",
         allowlist=STARTER_DOCS,
@@ -125,26 +126,33 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 0
 
 
-def _resolve_source_root() -> Path:
-    source_root = Path(__file__).resolve().parents[2]
+def _resolve_resource_root() -> resources.abc.Traversable:
+    try:
+        resource_root = resources.files(NOTEBOOK_WORKSPACE_RESOURCE_PACKAGE)
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Notebook starter templates are unavailable in this installation. "
+            f"Missing package resources: {NOTEBOOK_WORKSPACE_RESOURCE_PACKAGE}."
+        ) from exc
+
     missing = []
-    if not (source_root / "configs").is_dir():
+    if not resource_root.joinpath("configs").is_dir():
         missing.append("configs")
-    if not (source_root / "docs").is_dir():
+    if not resource_root.joinpath("docs").is_dir():
         missing.append("docs")
     if missing:
         joined = ", ".join(missing)
         raise RuntimeError(
             "Notebook starter templates are unavailable in this installation. "
-            f"Missing source directories: {joined}."
+            f"Missing resource directories: {joined}."
         )
-    return source_root
+    return resource_root
 
 
 def _copy_starters(
     *,
     workspace_root: Path,
-    source_root: Path,
+    resource_root: resources.abc.Traversable,
     source_folder: str,
     destination_folder: str,
     allowlist: Sequence[str],
@@ -155,9 +163,9 @@ def _copy_starters(
     skipped: list[str] = []
 
     for relative in allowlist:
-        source = source_root / source_folder / relative
+        source = _resource_path(resource_root, f"{source_folder}/{relative}")
         if not source.is_file():
-            raise FileNotFoundError(f"Starter template not found: {source.as_posix()}")
+            raise FileNotFoundError(f"Starter template not found: {source_folder}/{relative}")
 
         destination = _destination_path(workspace_root, f"{destination_folder}/{relative}")
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -171,7 +179,7 @@ def _copy_starters(
         else:
             copied.append(f"{destination_folder}/{relative}")
 
-        shutil.copy2(source, destination)
+        destination.write_bytes(source.read_bytes())
 
     return copied, overwritten, skipped
 
@@ -183,6 +191,16 @@ def _destination_path(workspace_root: Path, relative: str) -> Path:
             f"Refusing to write outside workspace root: {destination.as_posix()}"
         )
     return destination
+
+
+def _resource_path(
+    resource_root: resources.abc.Traversable,
+    relative: str,
+) -> resources.abc.Traversable:
+    candidate = resource_root
+    for part in relative.split("/"):
+        candidate = candidate.joinpath(part)
+    return candidate
 
 
 def print_summary(summary: dict[str, object]) -> None:

--- a/src/cli/init_notebook_workspace.py
+++ b/src/cli/init_notebook_workspace.py
@@ -120,7 +120,7 @@ def initialize_notebook_workspace(root: Path, *, force: bool = False) -> dict[st
 def main(argv: Sequence[str] | None = None) -> int:
     try:
         run_cli(argv)
-    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+    except (FileNotFoundError, NotADirectoryError, RuntimeError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     return 0
@@ -168,7 +168,13 @@ def _copy_starters(
             raise FileNotFoundError(f"Starter template not found: {source_folder}/{relative}")
 
         destination = _destination_path(workspace_root, f"{destination_folder}/{relative}")
-        destination.parent.mkdir(parents=True, exist_ok=True)
+        parent = destination.parent
+        if parent.exists() and not parent.is_dir():
+            raise NotADirectoryError(
+                "Expected parent directory for starter template but found non-directory path: "
+                f"{parent.as_posix()}"
+            )
+        parent.mkdir(parents=True, exist_ok=True)
 
         if destination.exists() and not destination.is_file():
             raise ValueError(

--- a/src/cli/init_notebook_workspace.py
+++ b/src/cli/init_notebook_workspace.py
@@ -170,6 +170,11 @@ def _copy_starters(
         destination = _destination_path(workspace_root, f"{destination_folder}/{relative}")
         destination.parent.mkdir(parents=True, exist_ok=True)
 
+        if destination.exists() and not destination.is_file():
+            raise ValueError(
+                f"Starter destination exists and is not a file: {destination.as_posix()}"
+            )
+
         if destination.exists() and not force:
             skipped.append(f"{destination_folder}/{relative}")
             continue

--- a/src/resources/notebook_workspace/configs/candidate_selection.yml
+++ b/src/resources/notebook_workspace/configs/candidate_selection.yml
@@ -1,0 +1,33 @@
+candidate_selection:
+  artifacts_root: artifacts/alpha
+  output_path: artifacts/candidate_selection
+
+  dataset: bars_daily
+  timeframe: 1D
+  evaluation_horizon: 5
+  mapping_name: rank_long_short
+  metric: ic_ir
+
+  eligibility:
+    min_ic: 0.01
+    min_ic_ir: 0.2
+    min_history_length: 60
+
+  redundancy:
+    max_correlation: 0.85
+    min_overlap_observations: 10
+
+  allocation:
+    method: equal_weight
+    max_weight: 0.2
+    min_candidates: 3
+
+  execution:
+    strict_mode: true
+    skip_eligibility: false
+    skip_redundancy: false
+    skip_allocation: false
+    enable_review: false
+
+  output:
+    registry_path: artifacts/candidate_selection/registry.jsonl

--- a/src/resources/notebook_workspace/configs/evaluation.yml
+++ b/src/resources/notebook_workspace/configs/evaluation.yml
@@ -1,0 +1,8 @@
+evaluation:
+  mode: rolling
+  timeframe: 1d
+  start: "2022-01-01"
+  end: "2024-01-01"
+  train_window: 12M
+  test_window: 3M
+  step: 3M

--- a/src/resources/notebook_workspace/configs/execution.yml
+++ b/src/resources/notebook_workspace/configs/execution.yml
@@ -1,0 +1,10 @@
+execution:
+  enabled: false
+  execution_delay: 1
+  transaction_cost_bps: 0.0
+  slippage_bps: 0.0
+  # Directional cost controls (optional - uncomment to enable)
+  # long_transaction_cost_bps: 3.0          # Separate cost for long positions, falls back to transaction_cost_bps if not set
+  # short_transaction_cost_bps: 5.0         # Separate cost for short positions, falls back to transaction_cost_bps if not set
+  # short_slippage_multiplier: 1.25         # Slippage multiplier for shorts (applied to slippage_bps)
+  # short_borrow_cost_bps: 25.0             # Borrow cost specific to short positions

--- a/src/resources/notebook_workspace/configs/features.yml
+++ b/src/resources/notebook_workspace/configs/features.yml
@@ -1,0 +1,37 @@
+# Feature registry for engineered datasets produced by the StratLake
+# feature pipeline.
+#
+# Purpose:
+# - documentation of available feature datasets
+# - discoverability of engineered feature columns and their source datasets
+# - reproducibility of feature datasets by recording the current grouped outputs
+
+features_daily_v1:
+  source_dataset: bars_daily
+  description: Daily feature set derived from curated daily OHLCV bars
+  features:
+    - feature_ret_1d
+    - feature_ret_5d
+    - feature_ret_20d
+    - feature_vol_20d
+    - feature_sma_20
+    - feature_sma_50
+    - feature_close_to_sma20
+  targets:
+    - target_ret_1d
+    - target_ret_5d
+  feature_aliases:
+    feature_sma_20:
+      - feature_sma20
+    feature_sma_50:
+      - feature_sma50
+
+features_1m_v1:
+  source_dataset: bars_1m
+  description: Intraday 1-minute feature set derived from curated 1-minute bars
+  features:
+    - feature_ret_1m
+    - feature_ret_5m
+    - feature_vol_30m
+    - feature_rv_30m
+    - feature_vol_ratio

--- a/src/resources/notebook_workspace/configs/pipelines/scenario_matrix_pipeline.yml
+++ b/src/resources/notebook_workspace/configs/pipelines/scenario_matrix_pipeline.yml
@@ -1,0 +1,148 @@
+id: scenario_matrix_pipeline
+parameters:
+  datasets:
+    features_daily:
+      consumers:
+        - alpha_rank_composite
+        - alpha_xgb
+        - alpha_lgbm
+        - strategy_momentum
+        - strategy_mean_reversion
+steps:
+  - id: alpha_rank_composite
+    adapter: python_module
+    module: src.cli.run_alpha
+    argv:
+      - --config
+      - configs/alphas_2026_q1.yml
+      - --alpha-name
+      - rank_composite_momentum_2026_q1
+      - --mode
+      - full
+      - --artifacts-root
+      - docs/examples/output/pipeline_scenario_matrix_case_study/artifacts/alpha
+  - id: alpha_xgb
+    adapter: python_module
+    module: src.cli.run_alpha
+    argv:
+      - --config
+      - configs/alphas_2026_q1.yml
+      - --alpha-name
+      - ml_cross_sectional_xgb_2026_q1
+      - --mode
+      - full
+      - --artifacts-root
+      - docs/examples/output/pipeline_scenario_matrix_case_study/artifacts/alpha
+  - id: alpha_lgbm
+    adapter: python_module
+    module: src.cli.run_alpha
+    argv:
+      - --config
+      - configs/alphas_2026_q1.yml
+      - --alpha-name
+      - ml_cross_sectional_lgbm_2026_q1
+      - --mode
+      - full
+      - --artifacts-root
+      - docs/examples/output/pipeline_scenario_matrix_case_study/artifacts/alpha
+  - id: strategy_momentum
+    adapter: python_module
+    module: src.cli.run_strategy
+    argv:
+      - --strategy
+      - momentum_v1
+      - --start
+      - "2026-01-01"
+      - --end
+      - "2026-04-03"
+  - id: strategy_mean_reversion
+    adapter: python_module
+    module: src.cli.run_strategy
+    argv:
+      - --strategy
+      - mean_reversion_v1_safe_2026_q1
+      - --start
+      - "2026-01-01"
+      - --end
+      - "2026-04-03"
+  - id: compare_alpha
+    depends_on:
+      - alpha_rank_composite
+      - alpha_xgb
+      - alpha_lgbm
+    adapter: python_module
+    module: src.cli.compare_alpha
+    argv:
+      - --from-registry
+      - --view
+      - combined
+      - --metric
+      - ic_ir
+      - --sleeve-metric
+      - sharpe_ratio
+      - --dataset
+      - features_daily
+      - --timeframe
+      - 1D
+      - --evaluation-horizon
+      - "5"
+      - --mapping-name
+      - top_bottom_quantile_q20
+      - --artifacts-root
+      - docs/examples/output/pipeline_scenario_matrix_case_study/artifacts/alpha
+      - --output-path
+      - docs/examples/output/pipeline_scenario_matrix_case_study/artifacts/comparisons/alpha
+  - id: compare_strategies
+    depends_on:
+      - strategy_momentum
+      - strategy_mean_reversion
+    adapter: python_module
+    module: src.cli.compare_strategies
+    argv:
+      - --strategies
+      - momentum_v1
+      - mean_reversion_v1_safe_2026_q1
+      - --start
+      - "2026-01-01"
+      - --end
+      - "2026-04-03"
+      - --metric
+      - sharpe_ratio
+      - --output-path
+      - docs/examples/output/pipeline_scenario_matrix_case_study/artifacts/comparisons/strategy
+  - id: candidate_selection
+    depends_on:
+      - compare_alpha
+    adapter: python_module
+    module: src.cli.run_candidate_selection
+    argv:
+      - --artifacts-root
+      - docs/examples/output/pipeline_scenario_matrix_case_study/artifacts/alpha
+      - --dataset
+      - features_daily
+      - --timeframe
+      - 1D
+      - --evaluation-horizon
+      - "5"
+      - --mapping-name
+      - top_bottom_quantile_q20
+      - --metric
+      - ic_ir
+      - --max-candidates
+      - "3"
+      - --allocation-method
+      - equal_weight
+      - --output-path
+      - docs/examples/output/pipeline_scenario_matrix_case_study/artifacts/candidate_selection
+  - id: construct_portfolio
+    depends_on:
+      - candidate_selection
+    adapter: python_module
+    module: src.cli.run_portfolio
+    argv:
+      - --portfolio-name
+      - scenario_matrix_pipeline_portfolio
+      - --timeframe
+      - 1D
+      - --output-dir
+      - docs/examples/output/pipeline_scenario_matrix_case_study/artifacts/portfolios

--- a/src/resources/notebook_workspace/configs/portfolios.yml
+++ b/src/resources/notebook_workspace/configs/portfolios.yml
@@ -1,0 +1,27 @@
+portfolios:
+  momentum_meanrev_equal:
+    allocator: equal_weight
+    initial_capital: 1.0
+    alignment_policy: intersection
+    components:
+      - strategy_name: momentum_v1
+      - strategy_name: mean_reversion_v1
+  momentum_meanrev_targeted:
+    allocator: equal_weight
+    initial_capital: 1.0
+    alignment_policy: intersection
+    components:
+      - strategy_name: momentum_v1
+      - strategy_name: mean_reversion_v1
+    volatility_targeting:
+      enabled: true
+      target_volatility: 0.10
+      lookback_periods: 20
+      volatility_epsilon: 1e-8
+  strict_valid_builtin_pair:
+    allocator: equal_weight
+    initial_capital: 1.0
+    alignment_policy: intersection
+    components:
+      - strategy_name: momentum_v1
+      - strategy_name: mean_reversion_v1

--- a/src/resources/notebook_workspace/configs/profiles/notebook.yml
+++ b/src/resources/notebook_workspace/configs/profiles/notebook.yml
@@ -1,0 +1,31 @@
+schema_version: 1
+profile: notebook
+description: Notebook-oriented profile for inspection with disposable outputs.
+use_case: Interactive analysis through importable execution APIs.
+settings:
+  marketlake_root: data/curated
+  features_root: data
+  artifacts_root: artifacts/notebooks
+  duckdb_path: ":memory:"
+  log_level: INFO
+  default_timezone: UTC
+workflow_configs:
+  config_dir: configs
+  execution_config: configs/execution.yml
+  sanity_config: configs/sanity.yml
+  review_config: configs/review.yml
+runtime:
+  execution:
+    enabled: false
+  strict_mode:
+    enabled: false
+review:
+  output:
+    emit_plots: true
+boundaries:
+  direct_scan: true
+  derived_outputs_authoritative: false
+  mutates_canonical_artifacts: false
+  requires_network: false
+  requires_credentials: false
+  requires_live_market_data: false

--- a/src/resources/notebook_workspace/configs/review.yml
+++ b/src/resources/notebook_workspace/configs/review.yml
@@ -1,0 +1,22 @@
+review:
+  filters:
+    run_types:
+      - alpha_evaluation
+      - strategy
+      - portfolio
+    timeframe:
+    dataset:
+    alpha_name:
+    strategy_name:
+    portfolio_name:
+    top_k_per_type:
+  ranking:
+    alpha_evaluation_primary_metric: ic_ir
+    alpha_evaluation_secondary_metric: mean_ic
+    strategy_primary_metric: sharpe_ratio
+    strategy_secondary_metric: total_return
+    portfolio_primary_metric: sharpe_ratio
+    portfolio_secondary_metric: total_return
+  output:
+    path:
+    emit_plots: true

--- a/src/resources/notebook_workspace/configs/strategies.yml
+++ b/src/resources/notebook_workspace/configs/strategies.yml
@@ -1,0 +1,167 @@
+# Strategy registry for research-layer strategy definitions.
+#
+# Purpose:
+# - document available strategy configurations
+# - keep strategy dataset requirements explicit and reproducible
+# - provide deterministic parameter sets for future loaders and runners
+
+momentum_v1:
+  dataset: features_daily
+  signal_type: ternary_quantile
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters:
+    lookback_short: 5
+    lookback_long: 20
+
+mean_reversion_v1:
+  dataset: features_daily
+  signal_type: ternary_quantile
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters:
+    lookback: 20
+    threshold: 1.0
+
+mean_reversion_v1_safe_2026_q1:
+  dataset: features_daily
+  signal_type: ternary_quantile
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters:
+    lookback: 20
+    threshold: 2.0
+
+buy_and_hold_v1:
+  dataset: features_daily
+  signal_type: binary_signal
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters: {}
+
+sma_crossover_v1:
+  dataset: features_daily
+  signal_type: binary_signal
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters:
+    fast_window: 5
+    slow_window: 20
+
+seeded_random_v1:
+  dataset: features_daily
+  signal_type: binary_signal
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters:
+    seed: 7
+
+time_series_momentum:
+  dataset: features_daily
+  signal_type: ternary_quantile
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters:
+    lookback_short: 5
+    lookback_long: 20
+
+cross_section_momentum:
+  dataset: features_daily
+  signal_type: cross_section_rank
+  signal_params: {}
+  position_constructor:
+    name: rank_dollar_neutral
+    params:
+      gross_long: 0.5
+      gross_short: 0.5
+  parameters:
+    lookback_days: 1
+
+mean_reversion:
+  dataset: features_daily
+  signal_type: ternary_quantile
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters:
+    lookback: 20
+    threshold: 1.0
+
+breakout:
+  dataset: features_daily
+  signal_type: ternary_quantile
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters:
+    lookback: 20
+
+pairs_trading:
+  dataset: features_daily
+  signal_type: spread_zscore
+  signal_params: {}
+  position_constructor:
+    name: zscore_clip_scale
+    params:
+      clip: 3.0
+      gross_exposure: 1.0
+  parameters:
+    lookback: 63
+    threshold: 2.0
+
+residual_momentum:
+  dataset: features_daily
+  signal_type: cross_section_rank
+  signal_params: {}
+  position_constructor:
+    name: rank_dollar_neutral
+    params:
+      gross_long: 0.5
+      gross_short: 0.5
+  parameters:
+    lookback_days: 20
+
+volatility_regime_momentum:
+  dataset: features_daily
+  signal_type: ternary_quantile
+  signal_params: {}
+  position_constructor:
+    name: identity_weights
+    params: {}
+  parameters:
+    lookback_short: 5
+    lookback_long: 20
+    volatility_lookback: 10
+    min_volatility: 0.002
+    max_volatility: 0.03
+
+weighted_cross_section_ensemble:
+  dataset: features_daily
+  signal_type: cross_section_rank
+  signal_params: {}
+  position_constructor:
+    name: rank_dollar_neutral
+    params:
+      gross_long: 0.5
+      gross_short: 0.5
+  parameters:
+    momentum_lookback_days: 5
+    residual_lookback_days: 20
+    momentum_weight: 0.6
+    residual_weight: 0.4

--- a/src/resources/notebook_workspace/docs/catalog_notebook_ergonomics.md
+++ b/src/resources/notebook_workspace/docs/catalog_notebook_ergonomics.md
@@ -1,0 +1,88 @@
+# Catalog Notebook Ergonomics
+
+M35 notebook helpers make robustness-aware catalog exploration easier without
+creating notebook-only execution paths. They are convenience wrappers over the
+same catalog, query, lineage, and explorer APIs used by the CLI.
+
+The helpers live in `src.catalog` and return plain Python objects suitable for
+display in notebooks or conversion to data frames.
+
+For the full M35 architecture and release-readiness context, see
+[`docs/m35_evidence_catalog_foundation.md`](m35_evidence_catalog_foundation.md)
+and [`docs/m35_release_notes.md`](m35_release_notes.md).
+
+## Helpers
+
+```python
+from src.catalog import (
+    build_catalog,
+    evidence_for_run,
+    evidence_lineage_rows,
+    find_governance_evidence,
+    find_release_evidence,
+    find_robustness_evidence,
+    find_validation_evidence,
+    render_notebook_markdown,
+)
+
+records = build_catalog("artifacts", repo_root=".")
+robustness_rows = find_robustness_evidence(records, robustness_status="needs_review")
+governance_rows = find_governance_evidence(records, governance_status="pass")
+validation_rows = find_validation_evidence(records)
+release_rows = find_release_evidence(records)
+
+run_view = evidence_for_run(records, "strategy_run_1", repo_root=".")
+lineage_rows = evidence_lineage_rows(records, run_id="strategy_run_1", repo_root=".")
+markdown = render_notebook_markdown(records, run_id="strategy_run_1", repo_root=".")
+```
+
+`build_notebook_evidence_view()` returns the same dictionary shape as
+`build_evidence_explorer_view()`. `render_notebook_markdown()`,
+`render_notebook_json()`, and `render_notebook_table()` call the shared explorer
+renderers.
+
+## CLI/API Parity
+
+These calls use the same filters as:
+
+```powershell
+python -m src.cli.query_catalog --record-family robustness_bundle --robustness-status needs_review
+python -m src.cli.explore_catalog_evidence --run-id strategy_run_1 --format markdown
+```
+
+Notebook helpers do not duplicate query, lineage, or explorer logic. They call
+`CatalogQuery`, `query_catalog()`, `build_lineage_edges()`,
+`build_evidence_explorer_view()`, and the explorer renderers.
+
+## Example
+
+Run the CI-safe notebook-style example:
+
+```powershell
+python docs/examples/catalog_evidence_notebook_workflow.py
+```
+
+The example creates synthetic artifacts in a temporary directory, builds a
+catalog, finds robustness and governance evidence, renders selected-run evidence,
+and prints JSON. It does not download data, require credentials, or write
+repository artifacts.
+
+## Determinism And Portability
+
+Helper outputs are deterministic and JSON-friendly:
+
+- table helpers return `list[dict[str, object]]`
+- single-run helpers return `dict[str, object]`
+- render helpers return strings
+- returned paths are repository-relative/POSIX-style catalog paths
+- no open file handles or `Path` objects are returned in JSON-like payloads
+
+## Boundary
+
+These helpers are a notebook/API ergonomics layer only. They do not add:
+
+- notebook-only workflow logic
+- duplicated CLI logic
+- a server or dashboard
+- a database, backend, search service, or canonical cache
+- policy replay, promotion mutation, or governance enforcement

--- a/src/resources/notebook_workspace/docs/concurrency_and_idempotency.md
+++ b/src/resources/notebook_workspace/docs/concurrency_and_idempotency.md
@@ -1,0 +1,157 @@
+# Concurrency and Idempotency
+
+## Purpose
+
+M28 hardens existing StratLake execution surfaces for repeated execution,
+notebook reruns, external orchestrator retries, shared output roots, and
+partial metadata writes.
+
+This work reinforces the existing CLI, `src.execution`, `src.pipeline`,
+research-campaign, benchmark-pack, and validation surfaces. It does not add a
+second pipeline framework, a replacement orchestration layer, or new workflow
+semantics.
+
+## Supported Guarantees
+
+StratLake uses simple file-system safeguards:
+
+- Artifact roots can be checked before writes with conservative collision
+  policy.
+- Metadata JSON/text writes use temp-file replacement where updated surfaces
+  call shared artifact-safety helpers.
+- Updated run roots can expose status markers:
+  `_RUNNING.json`, `_SUCCESS.json`, and `_FAILED.json`.
+- Completed roots are not considered successful until the final success marker
+  or complete manifest/summary has been written.
+- Interrupted or incomplete roots can be detected by missing success markers,
+  failed markers, running markers, checkpoints, partial summaries, or
+  incomplete manifests.
+
+These guarantees are local file-system guarantees. They are intended for
+research workflows, CI jobs, notebooks, and external scheduler retries that use
+clear output-root isolation.
+
+## Non-Goals
+
+M28 does not provide distributed locking, a database, Redis, a queue, a daemon,
+or a service. It does not require Airflow, Prefect, Dagster, or any other
+orchestration dependency. It does not make every artifact writer in the
+repository transactionally atomic.
+
+## Output-Root Isolation
+
+The safest pattern is one logical run per output root:
+
+- Pipeline artifacts write below `artifacts/pipelines/<pipeline_run_id>/`.
+- Research campaigns write below the configured `campaign_artifacts_root`.
+- Benchmark packs write below the configured benchmark-pack output root.
+- Validation reports write below the configured `artifacts/qa/` paths.
+
+For external orchestrator retries, prefer a unique output root per scheduler
+attempt unless the workflow explicitly supports checkpoint/resume. Good retry
+roots include a scheduler run id, attempt id, or timestamp supplied by the
+orchestrator.
+
+## Repeated Runs
+
+Some StratLake workflows intentionally support deterministic repeated runs:
+
+- Research campaigns can reuse matching checkpoint stages when
+  `reuse_policy.enable_checkpoint_reuse` is enabled.
+- Benchmark packs can resume partial batches and reuse completed batch
+  checkpoints.
+- Deterministic rerun validation intentionally creates first/second run roots
+  and may be rerun against the same validation workdir.
+
+When a workflow does not document checkpoint/resume semantics, repeated writes
+to a non-empty output root should be treated as a collision and should fail
+fast or use a new output root.
+
+## Concurrent Runs
+
+Concurrent runs should not share the same output root unless a workflow
+explicitly documents compatible checkpoint/reuse behavior. The M28 file-system
+markers make active, failed, and completed roots visible, but they are not a
+distributed lock and do not prevent all races between independent processes.
+
+If two processes target the same root at the same time, the supported guidance
+is to stop one run, inspect status markers and manifests, then rerun with a
+fresh output root or an explicit resume path.
+
+## Notebook Reruns
+
+Notebook cells should pass explicit output roots for rerunnable examples. Use
+`src.execution` helpers to run workflows and inspect `ExecutionResult`
+artifacts, manifests, summaries, and named output paths.
+
+For exploratory notebooks, prefer roots such as:
+
+- `artifacts/notebooks/<notebook_name>/<run_id>/`
+- `artifacts/notebooks/<notebook_name>/<cell_label>/attempt_<n>/`
+
+Avoid repeatedly writing into broad shared roots such as `artifacts/qa/` or
+`artifacts/research_campaigns/` unless the called workflow has documented
+checkpoint/resume behavior.
+
+## External Orchestrator Retries
+
+Airflow, Prefect, Dagster, CI, and scheduler usage should call existing CLI
+commands or `src.execution` APIs. They should not reimplement pipeline logic or
+introduce a parallel execution layer.
+
+Recommended retry behavior:
+
+- Use unique output roots for each orchestrator attempt by default.
+- Pass the same root only for workflows that explicitly support
+  checkpoint/resume.
+- Treat `_RUNNING.json` without `_SUCCESS.json` as an active or interrupted
+  run requiring inspection.
+- Treat `_FAILED.json` or partial checkpoints as resumable only when the
+  workflow documents resume semantics.
+
+## Checkpoint/Resume Compatibility
+
+Checkpoint-aware workflows may opt into reuse behavior:
+
+- Research campaigns validate stage fingerprints before reusing stages.
+- Benchmark packs validate batch fingerprints and existing summaries before
+  reusing batches.
+- Validation and deterministic rerun commands preserve their existing stable
+  rerun patterns.
+
+Reuse is explicit workflow behavior. It is not the default assumption for an
+arbitrary non-empty artifact root.
+
+## Manifest And Marker Semantics
+
+Updated surfaces write metadata artifacts atomically where practical and use
+status markers on representative run roots.
+
+Marker meanings:
+
+- `_RUNNING.json`: a run has started and has not yet written its final marker.
+- `_SUCCESS.json`: the run completed and final metadata was written.
+- `_FAILED.json`: the run failed or stopped in a partial state.
+
+Manifests and summaries remain the canonical workflow-specific artifact
+contracts. Markers are lightweight safety hints and should not replace
+manifest validation.
+
+## Collision Policies
+
+The shared artifact-safety helper supports:
+
+- `fail`: allow missing or empty roots, and fail on non-empty roots.
+- `reuse`: allow an existing root for workflows with explicit resume or
+  checkpoint semantics.
+
+The conservative default is `fail`. Workflows that already support
+checkpoint/resume can opt into `reuse` while preserving their own validation
+rules.
+
+## Limitations
+
+M28 hardening is intentionally local and practical. It does not prove
+distributed concurrency safety, transactional multi-file commits, or full
+cross-layer parity for every optional workflow. Broader parity validation and
+external orchestrator examples are deferred to later M28 issues.

--- a/src/resources/notebook_workspace/docs/cross_layer_validation.md
+++ b/src/resources/notebook_workspace/docs/cross_layer_validation.md
@@ -1,0 +1,125 @@
+# Cross-Layer Validation
+
+## Purpose
+
+Cross-layer validation proves that representative StratLake CLI, API,
+pipeline/orchestrator, and notebook-style entry points converge on the same
+underlying execution logic and equivalent canonical artifacts.
+
+The validation is artifact-first. It runs existing entry points, reads their
+machine-readable outputs, normalizes expected run-local differences, and
+compares the stable contract that downstream research and review workflows
+depend on.
+
+## Core Principle
+
+StratLake has one execution system with multiple entry points. Cross-layer
+validation compares stable artifacts from those entry points, not transient
+runtime behavior.
+
+This validation does not introduce a new execution framework, a new pipeline
+framework, or notebook-only workflow logic. It calls existing CLI helpers,
+`src.execution` APIs, and M28 example wrappers.
+
+## Supported Layers
+
+The current M28.5 implementation validates representative coverage for:
+
+- CLI entrypoints, using the benchmark-pack CLI argument path.
+- `src.execution` APIs, using `src.execution.run_benchmark_pack`.
+- Notebook-style examples from `docs/examples/notebooks/`.
+- External orchestrator fallback callables from `docs/examples/pipelines/`,
+  without requiring Airflow, Prefect, or Dagster to be installed.
+
+The benchmark pack is the canonical scenario because it is deterministic,
+lightweight enough for focused validation, and already emits summary,
+manifest, inventory, batch-plan, and benchmark-matrix artifacts.
+
+## Stable Comparison Contract
+
+Cross-layer validation compares stable machine-readable fields:
+
+- workflow name
+- logical benchmark-pack config identity
+- named output keys
+- manifest schema, run type, artifact files, and artifact groups
+- summary status, batch counts, scenario counts, and resume state
+- benchmark matrix columns, row counts, and deterministic rows
+- batch-plan fields and scenario identities
+- inventory relative entry paths
+- validation pass/fail status
+
+The validator normalizes or ignores expected unstable values:
+
+- absolute workspace paths
+- artifact root prefixes
+- output-root-specific paths
+- run IDs if an entry point generates them differently
+- timestamps
+- status marker `recorded_at_utc` values
+- stdout and stderr
+- ordering where the artifact contract does not require ordering
+- temporary files
+- `_RUNNING.json`, `_SUCCESS.json`, and `_FAILED.json` marker payload
+  timestamps
+- inventory hashes and byte sizes when path prefixes can change serialized
+  artifact contents
+
+## Validation Scenarios
+
+Implemented scenarios:
+
+- CLI vs `src.execution` API for benchmark-pack execution, using
+  `configs/benchmark_packs/m22_scale_repro.yml` with a one-batch stop point.
+- Notebook-style callable vs `src.execution` API, using
+  `docs/examples/notebooks/m28_benchmark_pack_execution_api.py`.
+- Prefect fallback callable vs `src.execution` API, using
+  `docs/examples/pipelines/m28_prefect_regime_research_flow.py` without
+  requiring Prefect.
+
+Deferred scenario:
+
+- Pipeline CLI/API parity is already covered by focused execution tests. A
+  separate cross-layer pipeline artifact comparison can be added when a small
+  M28-specific pipeline config is selected for this validator.
+
+## Running Validation
+
+Use the dedicated CLI:
+
+```powershell
+python -m src.cli.run_cross_layer_validation
+```
+
+The default report is:
+
+```text
+artifacts/qa/cross_layer_validation_report.json
+```
+
+The report is JSON and includes `run_type`, `schema_version`, `status`,
+scenario counts, per-scenario digests, differences, compared stable fields,
+normalized fields, and limitations.
+
+The milestone bundle can include this report explicitly:
+
+```powershell
+python -m src.cli.run_milestone_validation --include-cross-layer-validation
+```
+
+Cross-layer validation remains separate from the default deterministic-rerun
+command so M22 historical validation behavior stays unchanged.
+
+## Limitations
+
+This validation does not prove exhaustive parity for every optional config.
+
+This validation does not prove distributed locking.
+
+This validation does not replace full pytest, deterministic-rerun validation,
+or milestone validation.
+
+This validation does not imply live trading or production deployment
+readiness.
+
+M28.6 will provide the unified capstone case study.

--- a/src/resources/notebook_workspace/docs/examples/notebook_execution_api_examples.py
+++ b/src/resources/notebook_workspace/docs/examples/notebook_execution_api_examples.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.execution import (  # noqa: E402
+    ExecutionResult,
+    compare_strategies,
+    load_json_artifact,
+    run_alpha,
+    run_alpha_evaluation,
+    run_benchmark_pack,
+    run_campaign,
+    run_docs_path_lint,
+    run_deterministic_rerun_validation,
+    run_milestone_validation,
+    run_pipeline,
+    run_portfolio,
+    run_research_campaign,
+    run_strategy,
+)
+
+
+def inspect_result(result: ExecutionResult) -> dict[str, Any]:
+    """Return the notebook-safe inspection payload users usually want first."""
+
+    inspection: dict[str, Any] = {
+        "summary": result.notebook_summary(),
+        "output_keys": result.output_keys(),
+    }
+    if result.manifest_path is not None and result.manifest_path.exists():
+        inspection["manifest"] = result.load_manifest()
+    if any(result.has_output(key) for key in ("metrics_json", "alpha_metrics_json", "report_json")):
+        inspection["metrics_artifact"] = result.load_metrics_json()
+    if any(result.has_output(key) for key in ("summary_json", "qa_summary_json")):
+        inspection["summary_artifact"] = result.load_summary_json()
+    if result.has_output("comparison_json") and result.output_path("comparison_json").exists():
+        inspection["comparison_artifact"] = result.load_comparison_json()
+    return inspection
+
+
+def strategy_notebook_cell() -> tuple[ExecutionResult, dict[str, Any]]:
+    """Run one deterministic strategy and inspect its manifest and metrics."""
+
+    result = run_strategy(
+        "momentum_v1",
+        start="2022-01-01",
+        end="2023-01-01",
+        strict=True,
+    )
+
+    metrics = result.load_metrics_json()
+    manifest = result.load_manifest()
+    equity_curve_path = result.output_path("equity_curve_csv", must_exist=True)
+    return result, {
+        "notebook_summary": result.notebook_summary(),
+        "sharpe_ratio": metrics.get("sharpe_ratio"),
+        "manifest_run_id": manifest.get("run_id"),
+        "equity_curve_path": equity_curve_path,
+    }
+
+
+def strategy_comparison_notebook_cell() -> tuple[ExecutionResult, dict[str, Any]]:
+    """Compare strategy outputs from Python and inspect the leaderboard summary."""
+
+    result = compare_strategies(
+        ["momentum_v1", "mean_reversion_v1"],
+        start="2022-01-01",
+        end="2023-01-01",
+        metric="sharpe_ratio",
+    )
+
+    summary = result.load_summary_json()
+    leaderboard_path = result.output_path("leaderboard_csv", must_exist=True)
+    return result, {
+        "notebook_summary": result.notebook_summary(),
+        "leaderboard_path": leaderboard_path,
+        "metric": result.extra.get("metric"),
+        "row_count": summary.get("row_count", result.extra.get("row_count")),
+    }
+
+
+def alpha_evaluation_notebook_cell() -> tuple[ExecutionResult, dict[str, Any]]:
+    """Evaluate one alpha from an in-memory config mapping."""
+
+    result = run_alpha_evaluation(
+        config={
+            "alpha_name": "cs_linear_ret_1d",
+            "dataset": "features_daily",
+            "target_column": "target_ret_1d",
+            "price_column": "close",
+            "start": "2022-01-01",
+            "end": "2023-01-01",
+        }
+    )
+
+    alpha_metrics = result.load_metrics_json("alpha_metrics_json")
+    return result, {
+        "notebook_summary": result.notebook_summary(),
+        "mean_ic": alpha_metrics.get("mean_ic"),
+        "predictions_path": result.output_path("predictions_parquet", must_exist=True),
+        "manifest": result.load_manifest(),
+    }
+
+
+def alpha_full_run_notebook_cell() -> tuple[ExecutionResult, dict[str, Any]]:
+    """Run the full alpha surface and inspect signal and sleeve artifacts."""
+
+    result = run_alpha(
+        "cs_linear_ret_1d",
+        mode="full",
+        start="2022-01-01",
+        end="2023-01-01",
+    )
+
+    sleeve_metrics = result.load_metrics_json("sleeve_metrics_json")
+    return result, {
+        "notebook_summary": result.notebook_summary(),
+        "mode": result.extra.get("mode"),
+        "signals_path": result.output_path("signals_parquet", must_exist=True),
+        "sleeve_metrics": sleeve_metrics,
+    }
+
+
+def portfolio_notebook_cell(component_run_ids: list[str]) -> tuple[ExecutionResult, dict[str, Any]]:
+    """Build a portfolio from completed strategy or alpha-sleeve component runs."""
+
+    result = run_portfolio(
+        portfolio_name="core_portfolio",
+        run_ids=component_run_ids,
+        timeframe="1D",
+        strict=True,
+    )
+
+    portfolio_metrics = result.load_metrics_json()
+    return result, {
+        "notebook_summary": result.notebook_summary(),
+        "total_return": portfolio_metrics.get("total_return"),
+        "weights_path": result.output_path("weights_csv", must_exist=True),
+        "returns_path": result.output_path("portfolio_returns_csv", must_exist=True),
+    }
+
+
+def registry_backed_portfolio_notebook_cell() -> tuple[ExecutionResult, dict[str, Any]]:
+    """Build a portfolio from latest matching registry entries."""
+
+    result = run_portfolio(
+        portfolio_config_path="configs/portfolios.yml",
+        portfolio_name="momentum_meanrev_equal",
+        from_registry=True,
+        timeframe="1D",
+    )
+
+    return result, {
+        "notebook_summary": result.notebook_summary(),
+        "allocator": result.extra.get("allocator_name"),
+        "component_count": result.extra.get("component_count"),
+        "manifest": result.load_manifest(),
+    }
+
+
+def pipeline_notebook_cell() -> tuple[ExecutionResult, dict[str, Any]]:
+    """Run a YAML pipeline spec and inspect lineage, metrics, and state handoff."""
+
+    result = run_pipeline("configs/test_pipeline.yml")
+
+    return result, {
+        "notebook_summary": result.notebook_summary(),
+        "pipeline_metrics": result.load_metrics_json("pipeline_metrics_json"),
+        "lineage": result.load_output_json("lineage_json"),
+        "state": result.load_output_json("state_json"),
+        "execution_order": result.extra.get("execution_order"),
+    }
+
+
+def research_campaign_notebook_cell() -> tuple[ExecutionResult, dict[str, Any]]:
+    """Run one campaign config and inspect staged orchestration outputs."""
+
+    result = run_research_campaign(config_path="configs/research_campaign.yml")
+
+    return result, {
+        "notebook_summary": result.notebook_summary(),
+        "campaign_summary": result.load_summary_json(),
+        "checkpoint": result.load_output_json("checkpoint_json"),
+        "stage_statuses": result.extra.get("stage_statuses"),
+    }
+
+
+def scenario_orchestration_notebook_cell() -> tuple[ExecutionResult, dict[str, Any]]:
+    """Run a scenario-enabled campaign and inspect orchestration artifacts."""
+
+    result = run_campaign(
+        config_path="configs/research_campaign.yml",
+        overrides={
+            "scenarios": {
+                "enabled": True,
+                "max_scenarios": 4,
+                "matrix": [
+                    {
+                        "name": "top_k",
+                        "path": "comparison.top_k",
+                        "values": [5, 10],
+                    }
+                ],
+                "include": [
+                    {
+                        "scenario_id": "review_only",
+                        "overrides": {"review": {"filters": {"run_types": ["alpha_evaluation"]}}},
+                    }
+                ],
+            }
+        },
+    )
+
+    return result, {
+        "notebook_summary": result.notebook_summary(),
+        "orchestration_summary": result.load_summary_json(),
+        "scenario_catalog": result.load_output_json("scenario_catalog_json"),
+        "scenario_matrix_path": result.output_path("scenario_matrix_csv", must_exist=True),
+        "scenario_run_ids": result.extra.get("scenario_run_ids"),
+    }
+
+
+def validation_notebook_cell() -> dict[str, tuple[ExecutionResult, dict[str, Any]]]:
+    """Run validation reports from Python and keep failures inspectable."""
+
+    docs_result = run_docs_path_lint(output="artifacts/qa/docs_path_lint.json")
+    rerun_result = run_deterministic_rerun_validation(
+        workdir="artifacts/qa/rerun_workdir",
+        output="artifacts/qa/deterministic_rerun.json",
+    )
+    bundle_result = run_milestone_validation(
+        bundle_dir="artifacts/qa/milestone_validation_bundle",
+        include_full_pytest=False,
+    )
+
+    return {
+        "docs_path_lint": (
+            docs_result,
+            {
+                "status": docs_result.metrics.get("status"),
+                "report": docs_result.load_metrics_json("report_json"),
+            },
+        ),
+        "deterministic_rerun": (
+            rerun_result,
+            {
+                "status": rerun_result.metrics.get("status"),
+                "report": rerun_result.load_metrics_json("report_json"),
+            },
+        ),
+        "milestone_validation": (
+            bundle_result,
+            {
+                "status": bundle_result.metrics.get("status"),
+                "summary": bundle_result.load_summary_json("summary_json"),
+                "docs_lint_path": bundle_result.output_path("docs_path_lint_json"),
+                "rerun_path": bundle_result.output_path("deterministic_rerun_json"),
+            },
+        ),
+    }
+
+
+def benchmark_pack_notebook_cell() -> tuple[ExecutionResult, dict[str, Any]]:
+    """Run a benchmark pack and inspect summary, inventory, matrix, and comparison."""
+
+    result = run_benchmark_pack(
+        "configs/benchmark_packs/m22_scale_repro.yml",
+        output_root="artifacts/benchmark_packs/m22_scale_repro",
+    )
+
+    inspection: dict[str, Any] = {
+        "notebook_summary": result.notebook_summary(),
+        "summary": result.load_summary_json("summary_json"),
+        "inventory": result.load_output_json("inventory_json"),
+        "benchmark_matrix_path": result.output_path("benchmark_matrix_csv", must_exist=True),
+    }
+    if result.has_output("comparison_json") and result.output_path("comparison_json").exists():
+        inspection["comparison"] = result.load_comparison_json()
+    return result, inspection
+
+
+def explicit_artifact_load_notebook_cell(result: ExecutionResult) -> dict[str, Any]:
+    """Load a known JSON artifact path explicitly when it is not a named output."""
+
+    manifest = result.load_manifest()
+    extra_summary_path = manifest.get("artifact_paths", {}).get("summary")
+    if not extra_summary_path:
+        return {"manifest": manifest, "extra_summary": None}
+    return {
+        "manifest": manifest,
+        "extra_summary": load_json_artifact(
+            result.artifact_path(extra_summary_path, must_exist=True)
+        ),
+    }

--- a/src/resources/notebook_workspace/docs/getting_started.md
+++ b/src/resources/notebook_workspace/docs/getting_started.md
@@ -1,0 +1,382 @@
+# Getting Started
+
+## Overview
+
+StratLake Trade Engine is a deterministic strategy and portfolio research
+workflow built on curated market data. It does not ingest raw data. Instead,
+it reads validated datasets, builds features, runs strategies, applies
+execution and validation rules, and writes reproducible artifacts.
+
+This guide walks through the current repository workflow:
+
+1. set up the environment
+2. run the CI-safe first-run profile checks
+3. point the repo at curated data
+4. build or verify features
+5. run a strategy
+6. run the Milestone 11.5 alpha-to-portfolio example
+7. run the Milestone 12 alpha-evaluation example
+8. run the Milestone 13 review-and-promotion example
+9. run from notebooks or Python scripts
+10. run a strict strategy
+11. build a portfolio from saved runs
+
+For deeper detail, continue with:
+
+* [alpha_workflow.md](alpha_workflow.md)
+* [notebook_execution_api.md](notebook_execution_api.md)
+* [strategy_evaluation_workflow.md](strategy_evaluation_workflow.md)
+* [portfolio_construction_workflow.md](portfolio_construction_workflow.md)
+* [research_validity_framework.md](research_validity_framework.md)
+
+## Prerequisites
+
+Before running the CLI workflows, make sure you have:
+
+* Python 3.10 or newer
+* curated data produced by the upstream ingestion repository
+* permission to create a virtual environment and install dependencies
+* a local `.env` file with the correct paths
+
+Important environment settings:
+
+* `MARKETLAKE_ROOT`
+* `FEATURES_ROOT`
+* `ARTIFACTS_ROOT`
+* `DUCKDB_PATH`
+
+Runtime profiles provide non-secret starter contexts for local, CI, notebook,
+and pipeline workflows. See [runtime_profiles.md](runtime_profiles.md) and the
+examples in [../configs/profiles](../configs/profiles).
+
+From a clean checkout, the CI-safe first-run flow does not require live market
+data, credentials, network access, or external services:
+
+```powershell
+python -m src.cli.validate_config --profile ci
+python -m src.cli.stratlake_doctor --profile ci
+python -m src.cli.explain_config --profile ci --workflow strategy
+python docs/examples/m39_first_run_configuration_profile_example.py
+```
+
+Typical local values:
+
+```text
+MARKETLAKE_ROOT=/path/to/fintech-market-ingestion/data/curated
+FEATURES_ROOT=data
+ARTIFACTS_ROOT=artifacts
+DUCKDB_PATH=:memory:
+```
+
+## Repository Setup
+
+### 1. Create and activate a virtual environment
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+macOS or Linux:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+### 2. Install dependencies
+
+```powershell
+pip install -e .
+pip install -e ".[dev]"
+```
+
+### 3. Create `.env`
+
+Windows PowerShell:
+
+```powershell
+Copy-Item .env.example .env
+```
+
+macOS or Linux:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` so `MARKETLAKE_ROOT` points to the curated market-data root.
+
+## CI-Safe First Run
+
+M39 ships starter profiles for `local`, `ci`, `notebook`, and `pipeline`
+contexts. The `ci` profile is the safest first command path because it uses
+repository-relative paths, `:memory:` storage, checked-in config references, and
+explicit boundaries that keep network access, credentials, and live market data
+disabled.
+
+The first-run example writes deterministic advisory reports under
+`docs/examples/output/m39_first_run_configuration_profile_example/`:
+
+* `config_validation.json`
+* `environment_doctor.json`
+* `strategy_explain.json`
+* `synthetic_first_run_probe.json`
+* `summary.json`
+
+These files are generated, disposable, and non-authoritative. They prove setup
+readiness and pre-execution explainability; they do not run backtests, build
+features, construct portfolios, generate evidence packs, or mutate canonical
+artifacts. The default output directory is ignored so maintainers do not commit
+local first-run reports by accident.
+
+Notebook users can call the same APIs directly:
+
+```python
+from src.config.doctor import run_environment_doctor
+from src.config.explain import build_runtime_explain_report
+from src.config.resolution import resolve_runtime_profile_config
+
+resolved = resolve_runtime_profile_config("ci").to_json_dict()
+doctor = run_environment_doctor("ci").to_json_dict()
+explain = build_runtime_explain_report("ci", workflow="strategy").to_json_dict()
+```
+
+Pipeline users can run validation, doctor, and explain as preflight steps.
+Treat reports as advisory and disposable, and fail the pipeline only on explicit
+validation or doctor failures.
+
+## Build or Verify Features
+
+The example strategies in [../configs/strategies.yml](../configs/strategies.yml)
+use `features_daily`, so that dataset must already exist.
+
+If features are missing or stale, build them:
+
+```powershell
+python -m cli.build_features --timeframe 1D --start 2022-01-01 --end 2024-01-01 --tickers configs/tickers_50.txt
+```
+
+Notes:
+
+* `--start` is inclusive
+* `--end` is exclusive
+* daily features need enough history for rolling lookbacks
+
+## Run a Strategy
+
+Basic run:
+
+```powershell
+python -m src.cli.run_strategy --strategy momentum_v1
+```
+
+Bounded single-run window:
+
+```powershell
+python -m src.cli.run_strategy --strategy momentum_v1 --start 2022-01-01 --end 2023-01-01
+```
+
+Walk-forward run:
+
+```powershell
+python -m src.cli.run_strategy --strategy momentum_v1 --evaluation
+```
+
+The strategy CLI prints:
+
+* `strategy`
+* `run_id`
+* `cumulative_return`
+* `sharpe_ratio`
+
+It also writes artifacts under `artifacts/strategies/<run_id>/`.
+
+## Run The Milestone 11.5 Alpha Example Workflow
+
+The repository includes an end-to-end alpha example that demonstrates model
+registration, deterministic train/predict helpers, cross-sectional inspection,
+continuous-signal backtesting, and portfolio construction.
+
+```powershell
+python docs/examples/milestone_11_5_alpha_portfolio_workflow.py
+```
+
+See:
+
+* [alpha_workflow.md](alpha_workflow.md)
+* [examples/milestone_11_5_alpha_portfolio_workflow.md](examples/milestone_11_5_alpha_portfolio_workflow.md)
+* [milestone_11_portfolio_workflow.md](milestone_11_portfolio_workflow.md)
+
+## Run The Milestone 12 Alpha-Evaluation Example
+
+Milestone 12 adds deterministic alpha evaluation before signal mapping,
+including forward-return alignment, IC and Rank IC scoring, artifact
+persistence, registry-backed tracking, and leaderboard comparison.
+
+```powershell
+python docs/examples/alpha_evaluation_end_to_end.py
+```
+
+See:
+
+* [alpha_evaluation_workflow.md](alpha_evaluation_workflow.md)
+
+## Run The Milestone 13 Review-And-Promotion Example
+
+Milestone 13 adds a small committed end-to-end review example that loads
+completed alpha, strategy, and portfolio artifacts from checked-in registries,
+then writes one deterministic review pack plus a review-level promotion
+decision.
+
+```powershell
+python docs/examples/milestone_13_review_promotion_workflow.py
+```
+
+See:
+
+* [milestone_13_research_review_workflow.md](milestone_13_research_review_workflow.md)
+* [examples/milestone_13_review_promotion_workflow.md](examples/milestone_13_review_promotion_workflow.md)
+* [review_configuration.md](review_configuration.md)
+
+## Run With Strict Mode And Execution Frictions
+
+Example strict run with deterministic execution realism:
+
+```powershell
+python -m src.cli.run_strategy --strategy momentum_v1 --strict --execution-enabled --transaction-cost-bps 5 --slippage-bps 2
+```
+
+This run:
+
+* keeps lagged execution
+* applies deterministic costs and slippage
+* turns flagged sanity issues into blocking failures
+* persists effective runtime settings with the run when it succeeds
+
+See:
+
+* [strict_mode.md](strict_mode.md)
+* [execution_model.md](execution_model.md)
+* [runtime_configuration.md](runtime_configuration.md)
+
+## Run a Portfolio
+
+The portfolio runner consumes completed strategy artifacts.
+
+Registry-backed example:
+
+```powershell
+python -m src.cli.run_portfolio --portfolio-config configs/portfolios.yml --portfolio-name momentum_meanrev_equal --from-registry --timeframe 1D
+```
+
+Strict walk-forward example:
+
+```powershell
+python -m src.cli.run_portfolio --portfolio-config configs/portfolios.yml --portfolio-name strict_valid_builtin_pair --from-registry --evaluation configs/evaluation.yml --timeframe 1D --strict
+```
+
+Portfolio artifacts are written under `artifacts/portfolios/<run_id>/`.
+
+To exercise operational volatility targeting from the shipped config:
+
+```powershell
+python -m src.cli.run_portfolio --portfolio-config configs/portfolios.yml --portfolio-name momentum_meanrev_targeted --from-registry --timeframe 1D
+```
+
+## Run From Notebooks Or Python Scripts
+
+The same deterministic strategy, alpha, alpha-evaluation, portfolio, pipeline,
+campaign, validation, and benchmark-pack workflows are available through
+importable Python entrypoints:
+
+```python
+from src.execution import (
+    run_alpha,
+    run_alpha_evaluation,
+    run_benchmark_pack,
+    run_pipeline,
+    run_portfolio,
+    run_research_campaign,
+    run_strategy,
+)
+```
+
+These functions return `ExecutionResult` summaries with artifact paths,
+manifest paths, metrics, named outputs, and notebook-safe inspection helpers
+such as `output_keys()`, `output_path(...)`, `load_manifest()`,
+`load_metrics_json()`, `load_summary_json()`, `load_comparison_json()`, and
+`notebook_summary()`.
+
+Use notebooks for exploration, inspection, comparative analysis, and interactive
+review. Use the CLI for operational runs, automation, CI, milestone validation,
+and release-oriented workflows where process exit behavior matters.
+
+See:
+
+* [notebook_execution_api.md](notebook_execution_api.md)
+* [examples/notebook_execution_api_examples.md](examples/notebook_execution_api_examples.md)
+* [examples/notebook_execution_api_examples.py](examples/notebook_execution_api_examples.py)
+* [examples/ml_cross_sectional_xgb_2026_q1_notebook.ipynb](examples/ml_cross_sectional_xgb_2026_q1_notebook.ipynb)
+
+## What Gets Written
+
+### Strategy runs
+
+Common files:
+
+* `config.json`
+* `metrics.json`
+* `signal_diagnostics.json`
+* `qa_summary.json`
+* `equity_curve.csv`
+* `signals.parquet`
+* `manifest.json`
+
+### Portfolio runs
+
+Common files:
+
+* `config.json`
+* `components.json`
+* `weights.csv`
+* `portfolio_returns.csv`
+* `portfolio_equity_curve.csv`
+* `metrics.json`
+* `qa_summary.json`
+* `manifest.json`
+
+## Troubleshooting
+
+### `MARKETLAKE_ROOT` is missing or wrong
+
+Fix:
+
+* copy `.env.example` to `.env`
+* set `MARKETLAKE_ROOT` to the curated data directory
+* restart the shell if needed
+
+### `features_daily` is missing
+
+Fix:
+
+```powershell
+python -m cli.build_features --timeframe 1D --start 2022-01-01 --end 2024-01-01 --tickers configs/tickers_50.txt
+```
+
+### Strategy run fails under strict mode
+
+That usually means a sanity or validation issue that non-strict mode would have
+recorded as a warning. Review:
+
+* [strict_mode.md](strict_mode.md)
+* [research_integrity_and_qa.md](research_integrity_and_qa.md)
+
+## Next Docs
+
+* [cli_strategy_runner.md](cli_strategy_runner.md)
+* [strategy_comparison_cli.md](strategy_comparison_cli.md)
+* [portfolio_construction_workflow.md](portfolio_construction_workflow.md)
+* [research_validity_framework.md](research_validity_framework.md)

--- a/src/resources/notebook_workspace/docs/notebook_execution_api.md
+++ b/src/resources/notebook_workspace/docs/notebook_execution_api.md
@@ -1,0 +1,522 @@
+# Notebook Execution API
+
+## Overview
+
+The execution API exposes the repository's highest-value deterministic
+workflows through importable Python functions for notebooks and scripts. These
+entrypoints use the same execution foundations as the CLI runners: validation,
+runtime config precedence, artifact persistence, manifests, and registries are
+preserved.
+
+Use this surface when you want to run research workflows from Python without
+building subprocess calls or emulating shell arguments.
+
+```python
+from src.execution import (
+    compare_strategies,
+    load_json_artifact,
+    run_strategy,
+    run_alpha,
+    run_alpha_evaluation,
+    run_benchmark_pack,
+    run_docs_path_lint,
+    run_deterministic_rerun_validation,
+    run_milestone_validation,
+    run_portfolio,
+    run_pipeline,
+    run_research_campaign,
+)
+```
+
+Each function returns an `ExecutionResult`, a small notebook-friendly summary
+around the underlying workflow result.
+
+## When To Use Notebooks
+
+Use the Python execution API from notebooks when the work is exploratory or
+inspection-heavy: comparing runs, reviewing metrics, opening manifests,
+checking validation reports, walking through benchmark-pack inventories, or
+teaching a workflow interactively.
+
+Use the CLI for operational runs, automation, CI, release validation,
+scheduled benchmark packs, and milestone bundles where command-line arguments,
+stdout/stderr, and process exit behavior are part of the contract. Notebook
+execution complements the CLI; it does not replace the CLI as the release or
+automation interface.
+
+## Entrypoints
+
+### Strategy
+
+```python
+from src.execution import run_strategy
+
+result = run_strategy(
+    "momentum_v1",
+    start="2022-01-01",
+    end="2023-01-01",
+    strict=True,
+)
+
+result.workflow
+result.run_id
+result.metrics["sharpe_ratio"]
+result.artifact_dir
+result.manifest_path
+result.output_keys()
+result.load_metrics_json()
+```
+
+Strategy runs write the same deterministic strategy artifacts as the CLI, such
+as `metrics.json`, `qa_summary.json`, `equity_curve.csv`, and `manifest.json`.
+
+Strategy comparisons can also be launched from Python when you want a
+leaderboard in an interactive analysis:
+
+```python
+from src.execution import compare_strategies
+
+result = compare_strategies(
+    ["momentum_v1", "mean_reversion_v1"],
+    start="2022-01-01",
+    end="2023-01-01",
+    metric="sharpe_ratio",
+)
+
+result.output_path("leaderboard_csv")
+result.load_summary_json()
+```
+
+### Alpha Evaluation
+
+```python
+from src.execution import run_alpha_evaluation
+
+result = run_alpha_evaluation(
+    config={
+        "alpha_name": "cs_linear_ret_1d",
+        "dataset": "features_daily",
+        "target_column": "target_ret_1d",
+        "price_column": "close",
+        "start": "2022-01-01",
+        "end": "2023-01-01",
+    }
+)
+
+result.metrics["mean_ic"]
+result.output_path("alpha_metrics_json")
+result.output_path("predictions_parquet")
+result.manifest_path
+```
+
+`run_alpha_evaluation` also accepts `config_path=...` plus keyword overrides.
+The resolved run still follows the alpha evaluation validation, manifest, and
+registry behavior used by the CLI.
+
+### Alpha Full Run
+
+```python
+from src.execution import run_alpha
+
+result = run_alpha(
+    "cs_linear_ret_1d",
+    mode="full",
+    start="2022-01-01",
+    end="2023-01-01",
+)
+
+result.metrics["ic_ir"]
+result.output_path("signals_parquet")
+result.output_path("sleeve_metrics_json")
+result.extra["mode"]
+```
+
+Use `mode="evaluate"` when you only want the evaluation artifacts. Use
+`mode="full"` when you also want deterministic signal mapping, sleeve artifacts,
+and the full-run scaffold.
+
+### Portfolio
+
+Portfolio construction consumes completed component artifacts. A direct
+run-id-driven portfolio can be launched from Python like this:
+
+```python
+from src.execution import run_portfolio
+
+result = run_portfolio(
+    portfolio_name="core_portfolio",
+    run_ids=["momentum_run_id", "mean_reversion_run_id"],
+    timeframe="1D",
+    strict=True,
+)
+
+result.metrics["total_return"]
+result.output_path("weights_csv")
+result.output_path("portfolio_returns_csv")
+result.manifest_path
+```
+
+Config-driven and registry-backed portfolio runs are also available:
+
+```python
+result = run_portfolio(
+    portfolio_config_path="configs/portfolios.yml",
+    portfolio_name="momentum_meanrev_equal",
+    from_registry=True,
+    timeframe="1D",
+)
+```
+
+Portfolio outputs preserve the CLI artifact contract, including
+`components.json`, `weights.csv`, `portfolio_returns.csv`,
+`portfolio_equity_curve.csv`, `metrics.json`, `qa_summary.json`, and
+`manifest.json`.
+
+### Pipeline
+
+YAML pipeline specs can be launched directly from Python:
+
+```python
+from src.execution import run_pipeline
+
+result = run_pipeline("configs/test_pipeline.yml")
+
+result.run_id
+result.output_path("manifest_json")
+result.output_path("pipeline_metrics_json")
+result.output_path("lineage_json")
+result.output_path("state_json")
+result.extra["execution_order"]
+result.extra["state"]
+```
+
+`run_pipeline` uses `PipelineSpec.from_yaml(...)` and `PipelineRunner.run()`,
+the same path used by `python -m src.cli.run_pipeline`. It preserves
+deterministic pipeline ids, dependency ordering, pipeline state handoff,
+manifest writing, metrics, lineage, state artifacts, and registry updates.
+
+### Research Campaigns And Orchestration
+
+Campaign-style staged workflows are available through:
+
+```python
+from src.execution import run_research_campaign, run_campaign
+
+result = run_research_campaign(config_path="configs/research_campaign.yml")
+
+result.workflow
+result.run_id
+result.artifact_dir
+result.manifest_path
+result.output_path("checkpoint_json")
+result.output_path("summary_json")
+result.extra["stage_statuses"]
+result.extra["stage_execution"]
+result.load_summary_json()
+```
+
+`run_campaign(...)` is an alias. Both functions accept `config_path=...`, an
+in-memory config mapping, or a resolved `ResearchCampaignConfig`. They resolve
+configuration with the shared campaign config resolver and delegate to the
+existing campaign runner, so preflight checks, stage ordering, checkpoints,
+resume/reuse decisions, manifests, milestone reports, and downstream stage
+invocation stay CLI-equivalent.
+
+When the campaign config enables scenario expansion, the same function returns
+an orchestration summary:
+
+```python
+result = run_research_campaign(
+    config={
+        "scenarios": {"enabled": True},
+        # normal campaign config sections...
+    }
+)
+
+result.workflow  # "research_campaign_orchestration"
+result.output_path("scenario_catalog_json")
+result.output_path("scenario_matrix_csv")
+result.output_path("expansion_preflight_json")
+result.extra["scenarios"]
+result.extra["scenario_run_ids"]
+```
+
+Single-campaign results expose checkpoint and stage state references in
+`extra`; scenario orchestration results expose scenario catalogs, matrix
+artifacts, expansion preflight, and per-scenario run ids.
+
+### Validation
+
+Operational validation checks are exposed through the same execution layer:
+
+```python
+from src.execution import (
+    run_docs_path_lint,
+    run_deterministic_rerun_validation,
+    run_milestone_validation,
+)
+
+docs_result = run_docs_path_lint(output="artifacts/qa/docs_path_lint.json")
+rerun_result = run_deterministic_rerun_validation(
+    workdir="artifacts/qa/rerun_workdir",
+    output="artifacts/qa/deterministic_rerun.json",
+)
+bundle_result = run_milestone_validation(
+    bundle_dir="artifacts/qa/milestone_validation_bundle",
+    include_full_pytest=False,
+)
+```
+
+These wrappers preserve the CLI validation contracts. `run_docs_path_lint`
+writes the same docs/path lint JSON report and exposes it as
+`output_paths["report_json"]`. `run_deterministic_rerun_validation` writes the
+canonical rerun comparison report and exposes target/pass counts in `extra`.
+`run_milestone_validation` builds the milestone validation bundle without
+changing its schema; notebook callers can inspect
+`output_paths["summary_json"]`, `output_paths["docs_path_lint_json"]`, and
+`output_paths["deterministic_rerun_json"]`.
+
+CLI fail conditions are unchanged: the CLI runners still exit non-zero when
+their report status is not passed. The Python APIs return structured
+`ExecutionResult` objects with the same report payloads in `metrics` and
+`raw_result` so notebooks can inspect failures before deciding whether to
+raise.
+
+### Corporate-Actions Dividend Evidence
+
+M40 dividend evidence uses the public `src.corporate_actions` API rather than
+the `src.execution` workflow wrapper layer. That keeps dividend imports
+explicit and separate from strategy, alpha, portfolio, and backtest execution.
+
+```python
+from src.corporate_actions import import_dividend_events, load_dividend_events
+
+result = import_dividend_events(
+    source_data_path="data/external/corporate_actions/dividends/dividends.parquet",
+    source_metadata_path="data/external/corporate_actions/dividends/metadata.json",
+    output_root="data/curated/events/dividends",
+    artifact_root="artifacts/corporate_actions",
+    start="2024-01-01",
+    end="2025-01-01",
+    strict=True,
+)
+
+events = load_dividend_events("data/curated/events/dividends")
+result.to_dict()
+```
+
+For notebook review, load the curated dataset from the dataset root and inspect
+catalog evidence explicitly:
+
+```python
+from src.catalog import CatalogQuery, build_catalog, query_catalog
+
+records = build_catalog("artifacts", repo_root=".")
+dividend_records = query_catalog(records, CatalogQuery(evidence_type="dividend_events"))
+```
+
+These calls consume local files only. They do not call Alpaca, require
+credentials, adjust OHLCV bars, reconstruct adjusted prices, reinvest
+dividends, or mutate strategy, alpha, portfolio, promotion, or backtest
+outputs. See
+[Corporate Actions Dividend Evidence](corporate_actions_dividend_evidence.md).
+
+### Benchmark Packs
+
+Benchmark-pack execution is available from Python:
+
+```python
+from src.execution import run_benchmark_pack
+
+result = run_benchmark_pack(
+    "configs/benchmark_packs/m22_scale_repro.yml",
+    output_root="artifacts/benchmark_packs/m22_scale_repro",
+)
+
+result.run_id
+result.metrics["status"]
+result.output_path("summary_json")
+result.output_path("manifest_json")
+result.output_path("inventory_json")
+result.output_path("benchmark_matrix_csv")
+```
+
+The wrapper loads the same benchmark-pack config and delegates to the existing
+benchmark runner used by `python -m src.cli.run_benchmark_pack`. It preserves
+the deterministic output layout, checkpoint/resume behavior, manifest,
+inventory, benchmark matrix, and optional comparison report. Named paths include
+`summary_json`, `manifest_json`, `checkpoint_json`, `inventory_json`,
+`batch_plan_json`, `batch_plan_csv`, `benchmark_matrix_csv`,
+`benchmark_matrix_summary`, and `comparison_json` when a comparison is written.
+
+## `ExecutionResult` Contract
+
+Notebook entrypoints return `ExecutionResult` with these stable fields:
+
+* `workflow`: workflow family, such as `"strategy"`, `"alpha"`,
+  `"alpha_evaluation"`, `"portfolio"`, `"pipeline"`,
+  `"research_campaign"`, `"research_campaign_orchestration"`,
+  `"docs_path_lint"`, `"deterministic_rerun_validation"`,
+  `"milestone_validation"`, or `"benchmark_pack"`.
+* `run_id`: deterministic run identifier produced by the workflow.
+* `name`: strategy, alpha, portfolio, pipeline, or pack name.
+* `artifact_dir`: root directory for persisted artifacts, when the workflow
+  writes one.
+* `manifest_path`: expected or existing `manifest.json` path for the run.
+* `registry_path`: registry path when the execution wrapper exposes one.
+* `metrics`: summary metrics useful for notebook inspection.
+* `output_paths`: named artifact paths, such as `metrics_json`,
+  `alpha_metrics_json`, `weights_csv`, or `predictions_parquet`.
+* `extra`: deterministic workflow-specific metadata, such as alpha mode,
+  portfolio timeframe, allocator, pipeline state, campaign stage execution,
+  scenario summaries, validation check references, or benchmark-pack status.
+* `raw_result`: the original workflow result object for deeper inspection.
+
+The result also exposes lightweight inspection helpers for those same fields
+and paths. They are conveniences for reading existing artifacts, not alternate
+execution surfaces.
+
+Use `to_dict()` when you want a JSON-safe summary:
+
+```python
+payload = result.to_dict()
+payload["artifact_dir"]
+payload["metrics"]
+```
+
+By default, `to_dict()` excludes `raw_result` because raw workflow results may
+contain DataFrames, models, or other non-JSON objects. Pass
+`include_raw_result=True` only for local debugging.
+
+## Notebook Inspection Helpers
+
+`ExecutionResult` keeps the artifact-first contract visible while removing the
+small bits of notebook boilerplate that otherwise repeat across workflows.
+These helpers only inspect local paths already exposed by the result. They do
+not trigger execution, mutate files, create persistence, download data, or infer
+global state.
+
+Available helpers:
+
+* `output_keys()`: list named outputs in deterministic order.
+* `has_output(key)`: check whether an optional output was exposed.
+* `output_path(key, must_exist=False)`: fetch a named output path and raise a
+  clear `KeyError` when the key is absent. Set `must_exist=True` when the
+  notebook should fail immediately if the file is missing.
+* `artifact_path(*parts, must_exist=False)`: resolve a path under
+  `artifact_dir` without creating it. Paths that escape the artifact root are
+  rejected.
+* `load_manifest()`: load `manifest_path` as JSON and require an object payload.
+* `load_output_json(key)`: load JSON from an explicit named output path.
+* `load_metrics_json(key=None)`: load a metrics/report JSON output. Without a
+  key, it chooses the first available standard metrics key such as
+  `metrics_json`, `alpha_metrics_json`, `aggregate_metrics_json`,
+  `pipeline_metrics_json`, or `report_json`.
+* `load_summary_json(key=None)`: load a summary-style JSON output. Without a
+  key, it chooses the first available standard summary key such as
+  `summary_json`, `benchmark_matrix_summary`, `qa_summary_json`,
+  `training_summary_json`, or `report_json`.
+* `load_comparison_json(key="comparison_json")`: load a comparison JSON payload
+  when a workflow emitted one.
+* `notebook_summary()`: return a compact JSON-safe payload with identity,
+  artifact root, manifest path, metrics, output keys, and `extra`.
+* `load_json_artifact(path)`: module-level helper for loading any explicit
+  local JSON artifact path.
+
+Example inspection flow:
+
+```python
+result = run_strategy("momentum_v1", start="2022-01-01", end="2023-01-01")
+
+result.notebook_summary()
+result.output_keys()
+
+manifest = result.load_manifest()
+metrics = result.load_metrics_json()
+qa_summary = result.load_summary_json("qa_summary_json")
+
+equity_curve_path = result.output_path("equity_curve_csv", must_exist=True)
+```
+
+Optional outputs should be checked explicitly:
+
+```python
+result = run_benchmark_pack("configs/benchmark_packs/m22_scale_repro.yml")
+
+if result.has_output("comparison_json"):
+    comparison = result.load_comparison_json()
+```
+
+For workflow-specific reports, prefer loading by the named output key so the
+file being inspected remains obvious:
+
+```python
+summary = result.load_output_json("summary_json")
+docs_lint = result.load_output_json("docs_path_lint_json")
+```
+
+These helpers are intentionally narrow. Use `metrics` for the in-memory summary
+returned by the workflow, and use the `load_*` helpers when you want to inspect
+the machine-readable artifact that was written to disk.
+
+## CLI/API Parity Expectations
+
+The notebook execution API is expected to stay aligned with the corresponding
+CLI workflows on stable, machine-readable contracts. Parity tests cover
+representative strategy, alpha evaluation, portfolio, pipeline, validation, and
+benchmark-pack paths. They compare workflow identifiers, deterministic run ids,
+names, summary metrics, manifest references, named output path keys, artifact
+file names, and workflow-specific `extra` fields.
+
+Parity intentionally does not compare raw stdout text, object identity,
+absolute workspace prefixes, transient logs, or raw DataFrames/models attached
+to `raw_result`. CLI entrypoints may also apply process-oriented behavior, such
+as exiting non-zero when validation reports fail, while the API returns an
+`ExecutionResult` so notebooks can inspect the failed report.
+
+## Working With Artifacts
+
+The API is intentionally artifact-first. In notebooks, prefer using the
+structured paths instead of reconstructing filenames manually:
+
+```python
+metrics_path = result.output_paths["metrics_json"]
+manifest_path = result.manifest_path
+
+metrics_payload = result.metrics
+summary_payload = result.to_dict()
+```
+
+This keeps notebook code aligned with the same deterministic artifact contracts
+used by CLI and pipeline workflows.
+
+The helper equivalent keeps the same explicit paths while adding clearer
+missing-file behavior:
+
+```python
+metrics_path = result.output_path("metrics_json", must_exist=True)
+manifest_payload = result.load_manifest()
+metrics_artifact = result.load_metrics_json()
+summary_payload = result.notebook_summary()
+```
+
+## Canonical Examples
+
+See
+[`docs/examples/notebook_execution_api_examples.py`](examples/notebook_execution_api_examples.py)
+for import-safe notebook cell functions that demonstrate strategy, strategy
+comparison, alpha evaluation, full alpha, portfolio, pipeline, campaign,
+scenario orchestration, validation, and benchmark-pack calls through the public
+execution API.
+
+See
+[`docs/examples/notebook_execution_api_examples.md`](examples/notebook_execution_api_examples.md)
+for the notebook-oriented walkthrough, including CLI-versus-notebook guidance,
+interactive inspection patterns, validation report handling, and parity
+expectations.
+
+For a canonical `.ipynb` case-study artifact, see
+[`docs/examples/ml_cross_sectional_xgb_2026_q1_notebook.ipynb`](examples/ml_cross_sectional_xgb_2026_q1_notebook.ipynb).
+It demonstrates the Q1 2026 XGBoost alpha-to-portfolio workflow through
+`run_alpha`, `run_portfolio`, validation helpers, and `ExecutionResult`
+inspection methods.

--- a/src/resources/notebook_workspace/docs/notebook_integration.md
+++ b/src/resources/notebook_workspace/docs/notebook_integration.md
@@ -1,0 +1,225 @@
+# Notebook Integration
+
+## Purpose
+
+Notebook integration makes StratLake easier to use for interactive research,
+inspection, teaching, and review while preserving the same artifact contracts
+used by CLI, pipeline, validation, and orchestrated workflows. Use this guide
+with `docs/notebook_execution_api.md`, `docs/concurrency_and_idempotency.md`,
+and `docs/pipeline_integration.md`.
+
+Notebooks are an interactive surface over the existing StratLake execution
+system. They should run established workflows, inspect returned
+`ExecutionResult` objects, and read persisted artifacts. The source of truth is
+the artifact root, manifest, summaries, metrics, inventories, and named output
+paths, not hidden notebook cell state.
+
+## Core Principle
+
+StratLake has one execution system with multiple entry points. Notebook
+workflows should call existing `src.execution` APIs or CLI-equivalent paths and
+should not reimplement workflow logic.
+
+Notebook examples must not duplicate strategy, alpha, portfolio, pipeline,
+benchmark-pack, campaign, validation, regime, or stress-test behavior. They
+should remain thin cells that import StratLake APIs, pass explicit inputs, and
+inspect canonical outputs.
+
+## Local Notebook Workspace Bootstrap
+
+Use the installed bootstrap command to initialize a local notebook workspace
+under an explicit root path:
+
+```powershell
+stratlake-init-notebook --root ./stratlake-notebooks
+```
+
+This creates local `notebooks/`, `configs/`, `docs/`, `contracts/`, and
+`artifacts/` directories, copies a curated starter allowlist from repository
+`configs/` and `docs/`, and skips existing files by default. Use `--force` to
+overwrite copied starter templates only.
+
+See [`docs/notebook_workspace_bootstrap.md`](notebook_workspace_bootstrap.md)
+for command reference, installed CLI entry points, and package/workspace
+boundary guidance.
+
+## Existing Notebook Surface
+
+The public notebook-friendly execution surface is documented in
+[`docs/notebook_execution_api.md`](notebook_execution_api.md). Verified
+top-level imports from `src.execution` include:
+
+- `run_strategy`
+- `compare_strategies`
+- `run_alpha`
+- `run_alpha_evaluation`
+- `run_portfolio`
+- `run_pipeline`
+- `run_research_campaign`
+- `run_campaign`
+- `run_benchmark_pack`
+- `run_docs_path_lint`
+- `run_deterministic_rerun_validation`
+- `run_milestone_validation`
+- `ExecutionResult`
+- `load_json_artifact`
+
+Specialized regime and market-simulation execution wrappers also exist under
+module paths such as `src.execution.regime_benchmark`,
+`src.execution.regime_policy_stress_tests`,
+`src.execution.regime_promotion_gates`,
+`src.execution.regime_review_pack`, and
+`src.execution.market_simulation`. These are CLI-equivalent wrappers around
+their corresponding research and CLI surfaces.
+
+Every notebook-facing workflow should return or inspect an `ExecutionResult`.
+The stable contract includes `workflow`, `run_id`, `name`, `artifact_dir`,
+`manifest_path`, `metrics`, `output_paths`, `extra`, and `raw_result`.
+
+Use named output helpers instead of reconstructing filenames:
+
+```python
+result.notebook_summary()
+result.output_keys()
+result.output_path("summary_json", must_exist=True)
+result.load_manifest()
+result.load_metrics_json()
+result.load_summary_json("summary_json")
+```
+
+For explicit JSON artifacts that are not named outputs, use
+`load_json_artifact(path)` with a path obtained from a manifest or
+`ExecutionResult`.
+
+Run status markers from the M28 artifact-safety work may appear in reused roots:
+`_RUNNING.json`, `_SUCCESS.json`, and `_FAILED.json`. They are safety hints for
+active, completed, or failed roots. Manifests and workflow summaries remain the
+canonical contracts.
+
+Pipeline and external-orchestrator examples should follow
+[`docs/pipeline_integration.md`](pipeline_integration.md): wrap existing CLI or
+`src.execution` surfaces, pass explicit paths, and avoid scheduler-specific
+workflow logic in notebooks.
+
+## Notebook Rerun Safety
+
+Notebook cells are easy to rerun, so output-root isolation must be explicit:
+
+- Use explicit output roots where the called API supports them.
+- Use one logical notebook run per output root.
+- Include run ids, attempt ids, or cell labels for repeated cells.
+- Avoid writing repeatedly into broad shared roots such as `artifacts/qa/` or
+  `artifacts/research_campaigns/`.
+- When reusing roots intentionally, inspect `_RUNNING.json`, `_SUCCESS.json`,
+  `_FAILED.json`, manifests, summaries, checkpoints, and inventories before
+  deciding whether to resume or rerun.
+- Prefer read-only artifact inspection cells after execution.
+
+Good notebook roots include:
+
+```python
+"artifacts/notebooks/m28_benchmark_pack_execution_api/attempt_001"
+"artifacts/notebooks/m28_regime_research_inspection/attempt_001"
+```
+
+Some workflows, such as benchmark packs and research campaigns, document
+checkpoint or reuse behavior. Other workflows should be treated
+conservatively: use a fresh root or the workflow's default deterministic output
+layout rather than writing into a shared root from multiple notebook kernels.
+
+## CLI / API / Notebook Mapping
+
+| Workflow | Notebook API | CLI Equivalent | Primary Artifacts | Notes |
+| --- | --- | --- | --- | --- |
+| Strategy execution | `src.execution.run_strategy` | `python -m src.cli.run_strategy` | `manifest.json`, `metrics.json`, `qa_summary.json`, `equity_curve.csv` | Uses the same strategy runner and returns `ExecutionResult`. |
+| Strategy comparison | `src.execution.compare_strategies` | `python -m src.cli.compare_strategies` | leaderboard CSV, summary JSON, optional comparison JSON | Compare persisted strategy outputs through the shared comparison surface. |
+| Alpha evaluation | `src.execution.run_alpha_evaluation` | `python -m src.cli.run_alpha_evaluation` | `manifest.json`, `alpha_metrics.json`, predictions, signals | Config mapping or config path resolves through CLI-equivalent helpers. |
+| Full alpha run | `src.execution.run_alpha` | `python -m src.cli.run_alpha` | evaluation artifacts, mapped signals, sleeve metrics, scaffold | Use notebooks for inspection, not for custom signal-mapping logic. |
+| Portfolio execution | `src.execution.run_portfolio` | `python -m src.cli.run_portfolio` | `manifest.json`, `metrics.json`, weights, returns, equity curve | Consumes completed component artifacts or registry-backed inputs. |
+| Pipeline execution | `src.execution.run_pipeline` | `python -m src.cli.run_pipeline` | `manifest.json`, `pipeline_metrics.json`, `lineage.json`, `state.json` | Delegates to `PipelineSpec.from_yaml(...)` and `PipelineRunner.run()`. |
+| Benchmark-pack execution | `src.execution.run_benchmark_pack` | `python -m src.cli.run_benchmark_pack` | summary, manifest, checkpoint, inventory, batch plan, benchmark matrix | Supports explicit `output_root` and documented checkpoint/reuse semantics. |
+| Research-campaign execution | `src.execution.run_research_campaign` | `python -m src.cli.run_research_campaign` | campaign config, checkpoint, manifest, summary, preflight summary | Preserves campaign stage ordering, preflight, checkpoints, and reuse policy. |
+| Deterministic-rerun validation | `src.execution.run_deterministic_rerun_validation` | `python -m src.cli.run_deterministic_rerun_validation` | validation report JSON | Notebook API returns an inspectable result even when CLI policy would exit non-zero. |
+| Milestone-validation bundle | `src.execution.run_milestone_validation` | `python -m src.cli.run_milestone_validation` | bundle summary, docs/path lint report, deterministic-rerun report | Use CLI for release validation; use notebooks for interactive report review. |
+| Docs/path lint | `src.execution.run_docs_path_lint` | `python -m src.cli.run_docs_path_lint` | docs/path lint JSON report | Useful for notebook inspection of path-portability failures. |
+| Regime benchmark pack | `src.execution.regime_benchmark.run_regime_benchmark_pack` | `python -m src.cli.run_regime_benchmark_pack` | benchmark matrix, model/calibration/policy comparisons, summaries, manifest | Specialized regime wrapper, not exported from top-level `src.execution`. |
+| Regime review pack | `src.execution.regime_review_pack.generate_regime_review_pack` | `python -m src.cli.generate_regime_review_pack` | leaderboard, decision log, review summary, evidence index, manifest | Review artifact inspection should stay artifact-first. |
+| Regime policy stress tests | `src.execution.regime_policy_stress_tests.run_regime_policy_stress_tests` | `python -m src.cli.run_regime_policy_stress_tests` | stress matrices, scenario summaries, policy stress summary, manifest | Diagnostic research evidence, not production readiness evidence. |
+| Market simulation scenarios | `src.execution.market_simulation.run_market_simulation_scenarios` | `python -m src.cli.run_market_simulation_scenarios` | scenario catalogs, inventories, manifests, replay/bootstrap/Monte Carlo outputs | Simulation outputs are diagnostics, not forecasts. |
+
+Only use rows whose configs and input artifacts exist for the notebook you are
+running. Do not invent configs inside notebooks.
+
+## Canonical Notebook Patterns
+
+Import StratLake APIs inside a cell or helper function:
+
+```python
+from src.execution import run_benchmark_pack
+
+result = run_benchmark_pack(
+    "configs/benchmark_packs/m22_scale_repro.yml",
+    output_root="artifacts/notebooks/m28_benchmark_pack_execution_api/attempt_001",
+    stop_after_batches=1,
+)
+```
+
+Inspect the `ExecutionResult` before loading larger artifacts:
+
+```python
+result.notebook_summary()
+result.output_keys()
+```
+
+Load canonical artifacts through named outputs:
+
+```python
+summary = result.load_summary_json("summary_json")
+inventory = result.load_output_json("inventory_json")
+matrix_path = result.output_path("benchmark_matrix_csv", must_exist=True)
+```
+
+Compare notebook outputs to CLI-produced artifacts by comparing stable
+machine-readable contracts: workflow, run id, manifest references, named output
+keys, metrics, summaries, inventories, and matrix files. Do not compare object
+identity, transient stdout, absolute workspace prefixes, or hidden notebook
+state.
+
+Use pandas, matplotlib, or similar libraries only for inspection and display.
+Do not move workflow logic, artifact schema construction, signal generation,
+portfolio construction, policy selection, or validation decisions into notebook
+cells.
+
+Keep notebook outputs deterministic and clearable. A clean notebook or
+script-backed notebook example should be runnable from a fresh Python process
+with explicit inputs.
+
+## Examples
+
+Canonical M28 notebook-style examples live under `docs/examples/notebooks/`:
+
+- [`docs/examples/notebooks/m28_benchmark_pack_execution_api.ipynb`](examples/notebooks/m28_benchmark_pack_execution_api.ipynb)
+- [`docs/examples/notebooks/m28_strategy_execution_api.py`](examples/notebooks/m28_strategy_execution_api.py)
+- [`docs/examples/notebooks/m28_benchmark_pack_execution_api.py`](examples/notebooks/m28_benchmark_pack_execution_api.py)
+- [`docs/examples/notebooks/m28_regime_research_inspection.py`](examples/notebooks/m28_regime_research_inspection.py)
+
+The `.ipynb` file is output-free and lightweight. The `.py` files are
+script-backed notebook examples that are intentionally import-safe and can be
+copied into Jupyter cells without requiring Jupyter as a repository runtime
+dependency.
+
+## Limitations
+
+Notebooks are not a replacement for CI, release validation, benchmark-pack
+validation, milestone-validation bundles, or command-line automation.
+
+Notebook execution does not prove production readiness, live deployment
+readiness, future performance, or operational risk control.
+
+Full cross-layer CLI/API/pipeline/notebook parity validation is deferred to
+M28.5.
+
+The unified capstone case study is deferred to M28.6.
+
+Optional `.ipynb` execution depends on the local environment. This repository
+does not add Jupyter as a required runtime dependency for M28.4.

--- a/src/resources/notebook_workspace/docs/pipeline_integration.md
+++ b/src/resources/notebook_workspace/docs/pipeline_integration.md
@@ -1,0 +1,190 @@
+# Pipeline Integration
+
+## Purpose
+
+StratLake already has native execution and pipeline surfaces for deterministic
+research workflows. This guide explains how external orchestrators such as
+Airflow, Prefect, and Dagster can call those existing surfaces without adding a
+second StratLake workflow layer.
+
+The examples in `docs/examples/pipelines/` are integration patterns. They show
+how a scheduler task can invoke the same CLI modules or `src.execution` APIs
+used by notebooks, validation, and repository tests.
+
+## Core Principle
+
+StratLake has one execution system with multiple entry points. Airflow,
+Prefect, and Dagster examples must be thin wrappers around existing CLI or
+`src.execution` calls.
+
+External orchestrator code should not:
+
+- introduce a new internal pipeline abstraction
+- duplicate benchmark-pack, research-campaign, validation, or pipeline logic
+- bypass existing `src.execution` APIs or CLI entrypoints
+- add Airflow, Prefect, or Dagster as required runtime dependencies
+
+## Supported Existing Surfaces
+
+Verified `src.execution` surfaces include:
+
+- `src.execution.run_pipeline`
+- `src.execution.run_benchmark_pack`
+- `src.execution.run_research_campaign`
+- `src.execution.run_deterministic_rerun_validation`
+- `src.execution.run_milestone_validation`
+
+Verified CLI entrypoints include:
+
+```powershell
+python -m src.cli.run_pipeline --config configs/test_pipeline.yml
+python -m src.cli.run_benchmark_pack --config configs/benchmark_packs/m22_scale_repro.yml
+python -m src.cli.run_research_campaign --config configs/research_campaign.yml
+python -m src.cli.run_deterministic_rerun_validation
+python -m src.cli.run_milestone_validation
+```
+
+Prefer the Python API when the scheduler task wants an `ExecutionResult` with
+named artifact paths. Prefer the CLI when process exit behavior, stdout/stderr,
+or shell-friendly automation is the main contract.
+
+## Corporate-Actions Dividend Evidence Step
+
+M40 dividend evidence can be used in pipeline-style workflows as an explicit
+local-file import step. It should remain a thin call into
+`src.corporate_actions.import_dividend_events` or the matching CLI wrapper; it
+should not be hidden inside strategy, alpha, portfolio, or backtest execution.
+
+Python pattern:
+
+```python
+from src.corporate_actions import import_dividend_events
+
+
+def import_dividend_evidence_step() -> dict[str, object]:
+    result = import_dividend_events(
+        source_data_path="data/external/corporate_actions/dividends/dividends.parquet",
+        source_metadata_path="data/external/corporate_actions/dividends/metadata.json",
+        output_root="data/curated/events/dividends",
+        artifact_root="artifacts/corporate_actions",
+        start="2024-01-01",
+        end="2025-01-01",
+        strict=True,
+    )
+    return result.to_dict()
+```
+
+CLI pattern:
+
+```bash
+python -m src.cli.import_corporate_actions_dividends \
+  --source-data data/external/corporate_actions/dividends/dividends.parquet \
+  --source-metadata data/external/corporate_actions/dividends/metadata.json \
+  --output-root data/curated/events/dividends \
+  --artifact-root artifacts/corporate_actions \
+  --start 2024-01-01 \
+  --end 2025-01-01 \
+  --strict
+```
+
+This step consumes local upstream artifacts only. It does not call live APIs,
+require credentials, adjust price bars, reconstruct adjusted prices, model
+dividend reinvestment, or alter downstream research outputs. Generated import
+artifacts are evidence context for review and catalog discovery.
+
+See [Corporate Actions Dividend Evidence](corporate_actions_dividend_evidence.md)
+and `docs/examples/m40_dividend_pipeline_step_example.py`.
+
+## Artifact Safety and Idempotency
+
+External orchestrators should follow
+[`docs/concurrency_and_idempotency.md`](concurrency_and_idempotency.md):
+
+- use a unique output root for each orchestrator attempt by default
+- opt into explicit reuse only for workflows that document checkpoint/resume
+  behavior
+- do not share broad output roots across concurrent jobs
+- include scheduler run ids and attempt ids in output roots
+- inspect `_RUNNING.json`, `_SUCCESS.json`, and `_FAILED.json` markers when a
+  root may have been reused or interrupted
+- keep manifests, summaries, checkpoints, and inventories as the canonical
+  workflow contracts; marker files are safety hints, not replacements
+
+Research campaigns and benchmark packs have explicit checkpoint/reuse
+semantics. Other workflows should be treated conservatively: rerun with a new
+root unless the workflow documents safe reuse.
+
+## Environment Guidance
+
+Run orchestrated StratLake tasks from the repository root so relative config
+paths resolve consistently. Use isolated virtual environments for scheduler
+workers and keep scheduler-specific dependencies outside the core StratLake
+runtime unless they are installed as optional tooling.
+
+Set `MARKETLAKE_ROOT`, `ARTIFACTS_ROOT`, or other repository-supported runtime
+configuration variables only where the called workflow expects them. Keep CLI
+commands deterministic by passing explicit config paths, output roots, and
+run identifiers where the surface supports them.
+
+Do not rely on notebook state, imported module globals, or mutable process
+state from a prior scheduler task. Each task should be able to run from a clean
+Python process with explicit inputs.
+
+## Airflow Pattern
+
+Use a `PythonOperator` or `@task` to call a small local function. Import
+StratLake inside that callable so the DAG can still be parsed when a scheduler
+environment only needs to inspect the DAG structure.
+
+The callable should pass explicit output roots where possible, usually derived
+from Airflow `dag_run.run_id`, `task_instance.try_number`, or another attempt
+identifier. Keep heavy workflow logic out of the DAG definition and avoid
+placing Airflow-specific code in core StratLake modules.
+
+See
+[`docs/examples/pipelines/m28_airflow_regime_research_dag.py`](examples/pipelines/m28_airflow_regime_research_dag.py).
+
+## Prefect Pattern
+
+Use a Prefect `@task` as a thin call into `src.execution` or a CLI helper. A
+`@flow` can compose one or more StratLake tasks, but it should not reimplement
+StratLake workflow stages.
+
+Use unique output roots per flow run or task run. Pass the same root only for
+checkpoint/resume-aware workflows where reuse is intentional and documented.
+
+See
+[`docs/examples/pipelines/m28_prefect_regime_research_flow.py`](examples/pipelines/m28_prefect_regime_research_flow.py).
+
+## Dagster Pattern
+
+Use a Dagster `@op` to call an existing `src.execution` or CLI surface. A
+`@job` can compose ops, while StratLake remains responsible for benchmark-pack,
+research-campaign, pipeline, and validation logic.
+
+Keep ops thin, pass explicit paths, and avoid duplicating StratLake pipeline
+logic inside Dagster graphs.
+
+See
+[`docs/examples/pipelines/m28_dagster_regime_research_job.py`](examples/pipelines/m28_dagster_regime_research_job.py).
+
+## Validation Guidance
+
+Examples should remain import-safe without Airflow, Prefect, or Dagster
+installed. The repository examples expose plain Python fallback callables so
+unit tests can import them and inspect thin-wrapper behavior without optional
+scheduler packages.
+
+Tests can skip scheduler-object assertions when optional packages are absent.
+They should still verify that fallback callables exist, optional imports are
+guarded, and docs/path lint remains clean.
+
+## Limitations
+
+These examples are integration patterns, not production scheduler deployments.
+They do not provide distributed locking, scheduler installation guidance, or a
+full deployment topology.
+
+Orchestrator retry safety depends on output-root isolation and the semantics
+of the called workflow. Full cross-layer output parity is deferred to M28.5.
+The capstone case study is deferred to M28.6.

--- a/tests/test_github_actions_pinning.py
+++ b/tests/test_github_actions_pinning.py
@@ -15,6 +15,8 @@ EXPECTED_ACTION_PINS = {
     "actions/checkout": "34e114876b0b11c390a56381ad16ebd13914f8d5",
     "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
     "actions/upload-artifact": "ea165f8d65b6e75b540449e92b4886f43607fa02",
+    "actions/download-artifact": "d3f86a106a0bac45b974a628896c90dbdf5c8093",
+    "pypa/gh-action-pypi-publish": "cef221092ed1bacb1cc03d23a2d87d1d172e277b",
     "softprops/action-gh-release": "3bb12739c298aeb8a4eeaf626c5b8d85266b0e65",
 }
 

--- a/tests/test_init_notebook_workspace.py
+++ b/tests/test_init_notebook_workspace.py
@@ -76,6 +76,23 @@ def test_initialize_notebook_workspace_raises_for_non_file_starter_destination(
     assert conflicting_destination.as_posix() in message
 
 
+def test_initialize_notebook_workspace_rejects_file_where_parent_directory_is_required(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "notebook-workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    conflicting_parent = workspace_root / "configs" / "profiles"
+    conflicting_parent.parent.mkdir(parents=True, exist_ok=True)
+    conflicting_parent.write_text("not-a-directory\n", encoding="utf-8")
+
+    with pytest.raises(
+        NotADirectoryError,
+        match="Expected parent directory for starter template but found non-directory path",
+    ):
+        initialize_notebook_workspace(workspace_root)
+
+
 def test_run_cli_prints_concise_summary(tmp_path: Path, capsys) -> None:
     workspace_root = tmp_path / "notebook-workspace"
 

--- a/tests/test_init_notebook_workspace.py
+++ b/tests/test_init_notebook_workspace.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+import pytest
 
-from src.cli.init_notebook_workspace import initialize_notebook_workspace, run_cli
-
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from src.cli.init_notebook_workspace import (
+    _destination_path,
+    _resolve_resource_root,
+    initialize_notebook_workspace,
+    run_cli,
+)
 
 
 def test_initialize_notebook_workspace_creates_expected_layout(tmp_path: Path) -> None:
@@ -49,7 +52,9 @@ def test_initialize_notebook_workspace_force_overwrites_templates(tmp_path: Path
 
     summary = initialize_notebook_workspace(workspace_root, force=True)
 
-    source_text = (REPO_ROOT / "configs" / "features.yml").read_text(encoding="utf-8")
+    source_text = _resolve_resource_root().joinpath("configs").joinpath("features.yml").read_text(
+        encoding="utf-8"
+    )
     assert config_path.read_text(encoding="utf-8") == source_text
     assert "configs/features.yml" in summary["overwritten"]
 
@@ -62,3 +67,21 @@ def test_run_cli_prints_concise_summary(tmp_path: Path, capsys) -> None:
 
     assert "Initialized StratLake notebook workspace at:" in captured.out
     assert "Template status:" in captured.out
+
+
+def test_package_resources_are_discoverable() -> None:
+    resource_root = _resolve_resource_root()
+
+    assert resource_root.joinpath("configs").joinpath("features.yml").is_file()
+    assert resource_root.joinpath("configs").joinpath("profiles").joinpath("notebook.yml").is_file()
+    assert resource_root.joinpath("docs").joinpath("notebook_integration.md").is_file()
+    assert (
+        resource_root.joinpath("docs").joinpath("examples").joinpath("notebook_execution_api_examples.py").is_file()
+    )
+
+
+def test_destination_path_rejects_writes_outside_workspace_root(tmp_path: Path) -> None:
+    workspace_root = tmp_path.resolve()
+
+    with pytest.raises(ValueError):
+        _destination_path(workspace_root, "../outside.txt")

--- a/tests/test_init_notebook_workspace.py
+++ b/tests/test_init_notebook_workspace.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.cli.init_notebook_workspace import initialize_notebook_workspace, run_cli
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_initialize_notebook_workspace_creates_expected_layout(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "notebook-workspace"
+
+    summary = initialize_notebook_workspace(workspace_root)
+
+    for directory in ("notebooks", "configs", "docs", "contracts", "artifacts"):
+        assert (workspace_root / directory).is_dir()
+
+    assert (workspace_root / "configs" / "features.yml").is_file()
+    assert (workspace_root / "configs" / "profiles" / "notebook.yml").is_file()
+    assert (workspace_root / "docs" / "notebook_integration.md").is_file()
+    assert (workspace_root / "docs" / "examples" / "notebook_execution_api_examples.py").is_file()
+
+    assert summary["workspace_preexisting"] is False
+    assert len(summary["copied"]) > 0
+
+
+def test_initialize_notebook_workspace_does_not_overwrite_by_default(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "notebook-workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    config_path = workspace_root / "configs" / "features.yml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("sentinel\n", encoding="utf-8")
+
+    summary = initialize_notebook_workspace(workspace_root)
+
+    assert config_path.read_text(encoding="utf-8") == "sentinel\n"
+    assert "configs/features.yml" in summary["skipped"]
+
+
+def test_initialize_notebook_workspace_force_overwrites_templates(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "notebook-workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    config_path = workspace_root / "configs" / "features.yml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("sentinel\n", encoding="utf-8")
+
+    summary = initialize_notebook_workspace(workspace_root, force=True)
+
+    source_text = (REPO_ROOT / "configs" / "features.yml").read_text(encoding="utf-8")
+    assert config_path.read_text(encoding="utf-8") == source_text
+    assert "configs/features.yml" in summary["overwritten"]
+
+
+def test_run_cli_prints_concise_summary(tmp_path: Path, capsys) -> None:
+    workspace_root = tmp_path / "notebook-workspace"
+
+    run_cli(["--root", str(workspace_root)])
+    captured = capsys.readouterr()
+
+    assert "Initialized StratLake notebook workspace at:" in captured.out
+    assert "Template status:" in captured.out

--- a/tests/test_init_notebook_workspace.py
+++ b/tests/test_init_notebook_workspace.py
@@ -59,6 +59,23 @@ def test_initialize_notebook_workspace_force_overwrites_templates(tmp_path: Path
     assert "configs/features.yml" in summary["overwritten"]
 
 
+def test_initialize_notebook_workspace_raises_for_non_file_starter_destination(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "notebook-workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    conflicting_destination = workspace_root / "configs" / "features.yml"
+    conflicting_destination.mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(ValueError) as exc_info:
+        initialize_notebook_workspace(workspace_root)
+
+    message = str(exc_info.value)
+    assert "starter destination exists and is not a file" in message.lower()
+    assert conflicting_destination.as_posix() in message
+
+
 def test_run_cli_prints_concise_summary(tmp_path: Path, capsys) -> None:
     workspace_root = tmp_path / "notebook-workspace"
 

--- a/tests/test_notebook_bootstrap_wheel_smoke.py
+++ b/tests/test_notebook_bootstrap_wheel_smoke.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_WHEEL_NOTEBOOK_SMOKE_ENV_VAR = "STRATLAKE_RUN_NOTEBOOK_BOOTSTRAP_WHEEL_SMOKE"
+
+
+@pytest.mark.skipif(
+    os.environ.get(RUN_WHEEL_NOTEBOOK_SMOKE_ENV_VAR) != "1",
+    reason=(
+        "Notebook bootstrap wheel smoke test is opt-in. "
+        f"Set {RUN_WHEEL_NOTEBOOK_SMOKE_ENV_VAR}=1 to run."
+    ),
+)
+def test_wheel_install_supports_stratlake_init_notebook(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir(parents=True, exist_ok=True)
+
+    _run([sys.executable, "-m", "build", "--wheel", "--outdir", str(dist_dir)], cwd=REPO_ROOT)
+
+    wheel_paths = sorted(dist_dir.glob("*.whl"))
+    assert len(wheel_paths) == 1
+
+    venv_dir = tmp_path / "wheel-notebook-smoke-venv"
+    _run([sys.executable, "-m", "venv", str(venv_dir)], cwd=REPO_ROOT)
+
+    venv_python = _venv_python(venv_dir)
+    _run(
+        [str(venv_python), "-m", "pip", "install", "--force-reinstall", "--no-deps", str(wheel_paths[0])],
+        cwd=REPO_ROOT,
+    )
+
+    workspace_root = tmp_path / "stratlake-notebook-smoke"
+    script_name = "stratlake-init-notebook.exe" if os.name == "nt" else "stratlake-init-notebook"
+    script_path = _venv_scripts_dir(venv_dir) / script_name
+
+    _run([str(script_path), "--root", str(workspace_root)], cwd=tmp_path)
+
+    for relative in (
+        "notebooks",
+        "configs",
+        "docs",
+        "contracts",
+        "artifacts",
+    ):
+        assert (workspace_root / relative).is_dir()
+
+    assert (workspace_root / "configs" / "features.yml").is_file()
+    assert (workspace_root / "configs" / "profiles" / "notebook.yml").is_file()
+    assert (workspace_root / "docs" / "notebook_integration.md").is_file()
+    assert (workspace_root / "docs" / "examples" / "notebook_execution_api_examples.py").is_file()
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _venv_scripts_dir(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts"
+    return venv_dir / "bin"
+
+
+def _run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_packaging_readiness.py
+++ b/tests/test_packaging_readiness.py
@@ -42,7 +42,7 @@ def test_package_version_is_not_milestone_tag_formatted() -> None:
 
     # Milestone tags are repository-release identifiers (for example v0.36.0-foo),
     # while package versions stay PEP 440 distribution metadata.
-    assert not re.match(r"^v\d+\.\d+\.\d+-", declared_version)
+    assert not re.match(r"^v\d+\.\d+\.\d+(?:-|$)", declared_version)
 
 
 def test_stable_installed_import_smoke() -> None:

--- a/tests/test_packaging_readiness.py
+++ b/tests/test_packaging_readiness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from importlib import metadata
 from pathlib import Path
+import re
 import tomllib
 
 from src.artifacts.safety import portable_path
@@ -29,10 +30,19 @@ def test_pyproject_declares_explicit_package_discovery() -> None:
 
 
 def test_installed_project_metadata_is_available() -> None:
+    declared_version = _declared_project_version()
     project_metadata = metadata.metadata("stratlake-trade-engine")
 
     assert project_metadata["Name"] == "stratlake-trade-engine"
-    assert project_metadata["Version"] == "0.1.0"
+    assert project_metadata["Version"] == declared_version
+
+
+def test_package_version_is_not_milestone_tag_formatted() -> None:
+    declared_version = _declared_project_version()
+
+    # Milestone tags are repository-release identifiers (for example v0.36.0-foo),
+    # while package versions stay PEP 440 distribution metadata.
+    assert not re.match(r"^v\d+\.\d+\.\d+-", declared_version)
 
 
 def test_stable_installed_import_smoke() -> None:
@@ -41,3 +51,14 @@ def test_stable_installed_import_smoke() -> None:
 
 def _load_pyproject() -> dict[str, object]:
     return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _declared_project_version() -> str:
+    pyproject = _load_pyproject()
+    project_table = pyproject["project"]
+    assert isinstance(project_table, dict)
+
+    version = project_table["version"]
+    assert isinstance(version, str)
+    assert version
+    return version

--- a/tests/test_project_scripts.py
+++ b/tests/test_project_scripts.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+import tomllib
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+EXPECTED_SCRIPT_TARGETS = {
+    "stratlake-init-notebook": "src.cli.init_notebook_workspace:main",
+    "stratlake-run-strategy": "src.cli.run_strategy:main",
+    "stratlake-run-alpha": "src.cli.run_alpha:main",
+    "stratlake-run-alpha-evaluation": "src.cli.run_alpha_evaluation:main",
+    "stratlake-run-portfolio": "src.cli.run_portfolio:main",
+    "stratlake-run-pipeline": "src.cli.run_pipeline:main",
+    "stratlake-run-research-campaign": "src.cli.run_research_campaign:main",
+    "stratlake-run-benchmark-pack": "src.cli.run_benchmark_pack:main",
+    "stratlake-run-candidate-selection": "src.cli.run_candidate_selection:main",
+    "stratlake-review-candidate-selection": "src.cli.review_candidate_selection:main",
+    "stratlake-compare-strategies": "src.cli.compare_strategies:main",
+    "stratlake-compare-alpha": "src.cli.compare_alpha:main",
+    "stratlake-validate-config": "src.cli.validate_config:main",
+    "stratlake-doctor": "src.cli.stratlake_doctor:main",
+    "stratlake-explain-config": "src.cli.explain_config:main",
+    "stratlake-catalog-index": "src.cli.catalog_index:main",
+    "stratlake-query-catalog": "src.cli.query_catalog:main",
+    "stratlake-explore-catalog-evidence": "src.cli.explore_catalog_evidence:main",
+    "stratlake-export-catalog-lineage": "src.cli.export_catalog_lineage:main",
+    "stratlake-build-evidence-review": "src.cli.build_evidence_review:main",
+    "stratlake-run-promotion-governance-report": "src.cli.run_promotion_governance_report:main",
+}
+
+
+def test_pyproject_declares_expected_project_scripts() -> None:
+    pyproject = _load_pyproject()
+    scripts = pyproject["project"]["scripts"]
+
+    for script_name, target in EXPECTED_SCRIPT_TARGETS.items():
+        assert scripts.get(script_name) == target
+
+
+def test_project_script_targets_are_importable_callables() -> None:
+    pyproject = _load_pyproject()
+    scripts = pyproject["project"]["scripts"]
+
+    for target in scripts.values():
+        module_name, symbol_name = target.split(":", 1)
+        module = import_module(module_name)
+        symbol = getattr(module, symbol_name)
+        assert callable(symbol)
+
+
+def _load_pyproject() -> dict[str, object]:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Pull Request Title


Add Notebook Workspace Bootstrap and Installed CLI Entry Points


## Pull Request Description


## Summary

This PR adds notebook ergonomics support for StratLake by introducing a wheel-safe local workspace bootstrap command and installed CLI entry points.

The goal is to make StratLake easier to use from notebook-first and pip-installed workflows without requiring repository-root assumptions, hidden mutable state, or duplicated execution logic.

## Issues Resolved

Closes #447  
Closes #448  
Closes #449  

## Changes

### Notebook workspace bootstrap

Adds:

```bash
stratlake-init-notebook --root .
````

The command initializes a local notebook workspace with:

```text
notebooks/
configs/
docs/
contracts/
artifacts/
```

Bootstrap behavior:

* accepts `--root`, defaulting to the current directory
* supports `--force` for copied starter templates only
* skips existing files by default
* writes only under the selected workspace root
* does not write into `site-packages`
* does not create fake run artifacts
* preserves local workspace ownership of mutable files

### Wheel-safe packaged starter templates

Starter configs and docs are now bundled as package resources under:

```text
src/resources/notebook_workspace/
  configs/
  docs/
```

The bootstrap command loads these templates with `importlib.resources`, so it works from normal wheel/pip-installed environments as well as editable installs.

Package data is included through:

```toml
[tool.setuptools.package-data]
"src.resources.notebook_workspace" = ["**/*"]
```

### Installed CLI entry points

Adds `[project.scripts]` entries for common StratLake workflows, including:

```text
stratlake-init-notebook
stratlake-run-strategy
stratlake-run-alpha
stratlake-run-alpha-evaluation
stratlake-run-portfolio
stratlake-run-pipeline
stratlake-run-research-campaign
stratlake-run-benchmark-pack
stratlake-run-candidate-selection
stratlake-review-candidate-selection
stratlake-compare-strategies
stratlake-compare-alpha
stratlake-validate-config
stratlake-doctor
stratlake-explain-config
stratlake-catalog-index
stratlake-query-catalog
stratlake-explore-catalog-evidence
stratlake-export-catalog-lineage
stratlake-build-evidence-review
stratlake-run-promotion-governance-report
```

Existing `python -m src.cli...` workflows remain compatible.

### Documentation

Adds and updates notebook/workspace documentation:

* adds `docs/notebook_workspace_bootstrap.md`
* links the guide from `README.md`
* updates `docs/notebook_integration.md`
* clarifies package-vs-workspace boundaries
* clarifies that copied templates are local, user-owned, and mutable
* documents installed commands and troubleshooting guidance

### Packaging readiness fix

Updates `tests/test_packaging_readiness.py` so package version expectations derive from `pyproject.toml` instead of a stale hard-coded value.

Also updates README wording to preserve the distinction between:

* Python package version metadata
* milestone release tags

### GitHub Actions pinning fix

Resolves the remaining full-suite validation failures by:

* pinning mutable GitHub Actions references in `.github/workflows/publish-testpypi.yml`
* updating deterministic action inventory expectations
* updating M36 release/pinning documentation
* preserving full-SHA supply-chain hardening policy

## Validation

Completed validation:

```bash
python -m pytest tests/test_init_notebook_workspace.py -v
# passed

python -m pytest tests/test_project_scripts.py -v
# passed

python -m pytest tests/test_packaging_readiness.py -v
# passed

python -m pytest tests/test_github_actions_pinning.py -v
# passed

python -m pytest
# 2242 passed, 5 skipped, 0 failed

python -m ruff check .
# passed

python -m build
# passed
```

Wheel smoke validation also passed:

```bash
python -m build
python -m pip install <resolved-wheel-path> --force-reinstall
stratlake-init-notebook --root tmp/stratlake-notebook-smoke
```

Verified generated workspace included:

```text
notebooks/
configs/
docs/
contracts/
artifacts/
configs/features.yml
configs/profiles/notebook.yml
docs/notebook_integration.md
docs/examples/notebook_execution_api_examples.py
```

## Architecture Boundaries Preserved

This PR does not:

* add a new execution engine
* duplicate workflow logic
* create hidden global state
* write runtime outputs into `site-packages`
* make copied configs authoritative over explicit user paths
* create fake canonical artifacts during bootstrap
* break existing `python -m src.cli...` workflows

## Final Status

```text
Issue #447: resolved
Issue #448: resolved
Issue #449: resolved
Full pytest: green
Ruff: passed
Build: passed
Wheel bootstrap smoke: passed
Branch: PR-ready
```



