### PR TITLE
M41: Add feature build runtime overrides

### DIFF
--- a/cli/build_features.py
+++ b/cli/build_features.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence
@@ -10,6 +12,7 @@ from typing import Any, Sequence
 import pandas as pd
 
 from src.config.settings import Settings
+from src.data.catalog import CuratedPaths
 from src.pipeline.feature_pipeline import (
     run_daily_feature_pipeline,
     run_minute_feature_pipeline,
@@ -20,13 +23,44 @@ SUPPORTED_TIMEFRAMES = ("1Min", "1D")
 NON_FEATURE_COLUMNS = {"symbol", "ts_utc", "timeframe", "date"}
 
 
+@dataclass(frozen=True)
+class FeatureBuildRuntime:
+    settings: Settings
+    marketlake_root_source: str
+
+    @property
+    def config_resolution(self) -> dict[str, dict[str, str]]:
+        return {
+            "marketlake_root": {
+                "value": str(self.settings.marketlake_root),
+                "source": self.marketlake_root_source,
+            }
+        }
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build feature datasets from curated marketlake bars.")
     parser.add_argument("--timeframe", choices=SUPPORTED_TIMEFRAMES, required=True)
     parser.add_argument("--start", required=True, dest="start")
     parser.add_argument("--end", required=True, dest="end")
     parser.add_argument("--tickers", required=True, dest="tickers")
+    parser.add_argument(
+        "--marketlake-root",
+        type=Path,
+        help="Override the curated MarketLake root for this feature-build run.",
+    )
     return parser.parse_args(argv)
+
+
+def resolve_feature_build_runtime(args: argparse.Namespace, settings: Settings) -> FeatureBuildRuntime:
+    if args.marketlake_root is not None:
+        return FeatureBuildRuntime(
+            settings=replace(settings, marketlake_root=Path(args.marketlake_root)),
+            marketlake_root_source="cli",
+        )
+
+    source = "environment" if os.getenv("MARKETLAKE_ROOT") else "paths_config"
+    return FeatureBuildRuntime(settings=settings, marketlake_root_source=source)
 
 
 def load_tickers(tickers_file: str | Path) -> list[str]:
@@ -125,12 +159,13 @@ def build_summary(
     features: pd.DataFrame,
     marketlake_root: Path,
     input_partitions_used: Sequence[str],
+    config_resolution: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     processed_symbols = []
     if "symbol" in features.columns and not features.empty:
         processed_symbols = sorted(features["symbol"].dropna().astype(str).unique().tolist())
 
-    return {
+    summary = {
         "run_id": run_id,
         "timeframe": timeframe,
         "start": start,
@@ -143,6 +178,9 @@ def build_summary(
         "input_partitions_used": list(input_partitions_used),
         "missingness_by_feature_column": compute_missingness(features),
     }
+    if config_resolution is not None:
+        summary["config_resolution"] = config_resolution
+    return summary
 
 
 def configure_logging(log_level: str) -> None:
@@ -154,7 +192,8 @@ def configure_logging(log_level: str) -> None:
 
 def run_cli(argv: Sequence[str] | None = None) -> Path:
     args = parse_args(argv)
-    settings = Settings.load()
+    runtime = resolve_feature_build_runtime(args, Settings.load())
+    settings = runtime.settings
     configure_logging(settings.log_level)
 
     tickers = load_tickers(args.tickers)
@@ -167,7 +206,11 @@ def run_cli(argv: Sequence[str] | None = None) -> Path:
         marketlake_root=settings.marketlake_root,
     )
 
-    LOGGER.info("Resolved MARKETLAKE_ROOT=%s", settings.marketlake_root)
+    LOGGER.info(
+        "Resolved MARKETLAKE_ROOT=%s source=%s",
+        settings.marketlake_root,
+        runtime.marketlake_root_source,
+    )
     LOGGER.info("Resolved timeframe=%s", args.timeframe)
     LOGGER.info("Input partitions used=%s", input_partitions)
     LOGGER.info("Run ID=%s", run_id)
@@ -177,6 +220,7 @@ def run_cli(argv: Sequence[str] | None = None) -> Path:
         tickers,
         start_date=args.start,
         end_date=args.end,
+        paths=CuratedPaths(root=settings.marketlake_root),
         qa_artifacts_root=settings.artifacts_root / "qa" / "features",
     )
 
@@ -190,6 +234,7 @@ def run_cli(argv: Sequence[str] | None = None) -> Path:
         features=features,
         marketlake_root=settings.marketlake_root,
         input_partitions_used=input_partitions,
+        config_resolution=runtime.config_resolution,
     )
     artifact_root = settings.artifacts_root / "feature_runs" / run_id
     summary_path = write_summary(summary, artifact_root)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -159,6 +159,17 @@ If features are missing or stale, build them:
 python -m cli.build_features --timeframe 1D --start 2022-01-01 --end 2024-01-01 --tickers configs/tickers_50.txt
 ```
 
+Installed package environments can use the packaged console script:
+
+```powershell
+stratlake-build-features --timeframe 1D --start 2025-01-01 --end 2025-02-01 --tickers configs/tickers_50.txt --marketlake-root data/curated
+```
+
+Feature builds resolve the curated MarketLake root in this order:
+`--marketlake-root`, then `MARKETLAKE_ROOT`, then `configs/paths.yml`.
+The override is local to the feature-build run and does not edit `.env` or
+`configs/paths.yml`.
+
 Notes:
 
 * `--start` is inclusive
@@ -313,6 +324,38 @@ such as `output_keys()`, `output_path(...)`, `load_manifest()`,
 Use notebooks for exploration, inspection, comparative analysis, and interactive
 review. Use the CLI for operational runs, automation, CI, milestone validation,
 and release-oriented workflows where process exit behavior matters.
+
+Feature building is also importable for notebook cells that want the same thin
+CLI behavior without shelling out. Environment-driven notebook setup:
+
+```python
+import os
+
+os.environ["MARKETLAKE_ROOT"] = "data/curated"
+
+from cli.build_features import run_cli
+
+summary_path = run_cli([
+    "--timeframe", "1D",
+    "--start", "2025-01-01",
+    "--end", "2025-02-01",
+    "--tickers", "configs/tickers_50.txt",
+])
+```
+
+Cell-local root override:
+
+```python
+from cli.build_features import run_cli
+
+summary_path = run_cli([
+    "--timeframe", "1D",
+    "--start", "2025-01-01",
+    "--end", "2025-02-01",
+    "--tickers", "configs/tickers_50.txt",
+    "--marketlake-root", "data/curated",
+])
+```
 
 See:
 

--- a/docs/notebook_integration.md
+++ b/docs/notebook_integration.md
@@ -132,6 +132,7 @@ layout rather than writing into a shared root from multiple notebook kernels.
 | Workflow | Notebook API | CLI Equivalent | Primary Artifacts | Notes |
 | --- | --- | --- | --- | --- |
 | Strategy execution | `src.execution.run_strategy` | `python -m src.cli.run_strategy` | `manifest.json`, `metrics.json`, `qa_summary.json`, `equity_curve.csv` | Uses the same strategy runner and returns `ExecutionResult`. |
+| Feature building | `cli.build_features.run_cli` | `python -m cli.build_features` or `stratlake-build-features` | feature run `summary.json`, feature datasets, QA rollups | Use `--marketlake-root` for a cell-local curated-data root override. |
 | Strategy comparison | `src.execution.compare_strategies` | `python -m src.cli.compare_strategies` | leaderboard CSV, summary JSON, optional comparison JSON | Compare persisted strategy outputs through the shared comparison surface. |
 | Alpha evaluation | `src.execution.run_alpha_evaluation` | `python -m src.cli.run_alpha_evaluation` | `manifest.json`, `alpha_metrics.json`, predictions, signals | Config mapping or config path resolves through CLI-equivalent helpers. |
 | Full alpha run | `src.execution.run_alpha` | `python -m src.cli.run_alpha` | evaluation artifacts, mapped signals, sleeve metrics, scaffold | Use notebooks for inspection, not for custom signal-mapping logic. |
@@ -193,6 +194,43 @@ cells.
 Keep notebook outputs deterministic and clearable. A clean notebook or
 script-backed notebook example should be runnable from a fresh Python process
 with explicit inputs.
+
+Feature-builder cells can use the same CLI-equivalent parser while returning
+the summary artifact path. Environment-driven setup:
+
+```python
+import os
+
+os.environ["MARKETLAKE_ROOT"] = "data/curated"
+
+from cli.build_features import run_cli
+
+summary_path = run_cli([
+    "--timeframe", "1D",
+    "--start", "2025-01-01",
+    "--end", "2025-02-01",
+    "--tickers", "configs/tickers_50.txt",
+])
+```
+
+For a visible cell-local override, pass `--marketlake-root` directly:
+
+```python
+from cli.build_features import run_cli
+
+summary_path = run_cli([
+    "--timeframe", "1D",
+    "--start", "2025-01-01",
+    "--end", "2025-02-01",
+    "--tickers", "configs/tickers_50.txt",
+    "--marketlake-root", "data/curated",
+])
+```
+
+The feature builder resolves the curated root as `--marketlake-root`,
+`MARKETLAKE_ROOT`, then `configs/paths.yml`. The direct override is local to
+that run and does not mutate `.env`, `configs/paths.yml`, or global process
+configuration.
 
 ## Examples
 

--- a/docs/notebook_workspace_bootstrap.md
+++ b/docs/notebook_workspace_bootstrap.md
@@ -61,6 +61,7 @@ the local workspace files are user-owned and mutable.
 The package now provides stable installed entry points for common workflows:
 
 - `stratlake-init-notebook`
+- `stratlake-build-features`
 - `stratlake-run-strategy`
 - `stratlake-run-alpha`
 - `stratlake-run-alpha-evaluation`
@@ -86,6 +87,7 @@ Python module invocations remain compatible, for example:
 
 ```powershell
 python -m src.cli.run_strategy --strategy momentum_v1
+python -m cli.build_features --timeframe 1D --start 2025-01-01 --end 2025-02-01 --tickers configs/tickers_50.txt
 ```
 
 ## Package Versus Workspace Boundaries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
 
 [project.scripts]
 stratlake-init-notebook = "src.cli.init_notebook_workspace:main"
+stratlake-build-features = "cli.build_features:main"
 stratlake-run-strategy = "src.cli.run_strategy:main"
 stratlake-run-alpha = "src.cli.run_alpha:main"
 stratlake-run-alpha-evaluation = "src.cli.run_alpha_evaluation:main"

--- a/tests/test_build_features_cli.py
+++ b/tests/test_build_features_cli.py
@@ -426,6 +426,7 @@ def test_run_cli_marketlake_root_override_precedes_environment_and_config(
 
 
 def test_pyproject_registers_build_features_console_script() -> None:
-    pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject_text = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
 
     assert 'stratlake-build-features = "cli.build_features:main"' in pyproject_text

--- a/tests/test_build_features_cli.py
+++ b/tests/test_build_features_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -12,6 +13,7 @@ from cli.build_features import (
     compute_missingness,
     load_tickers,
     parse_args,
+    resolve_feature_build_runtime,
     resolve_input_partitions,
     run_cli,
     write_summary,
@@ -62,7 +64,98 @@ def test_parse_args_and_load_tickers(tmp_path: Path) -> None:
     assert args.start == "2025-11-01"
     assert args.end == "2025-12-01"
     assert args.tickers == str(tickers_file)
+    assert args.marketlake_root is None
     assert load_tickers(tickers_file) == ["AAPL", "MSFT"]
+
+
+def test_parse_args_accepts_marketlake_root(tmp_path: Path) -> None:
+    tickers_file = tmp_path / "tickers.txt"
+    marketlake_root = tmp_path / "curated"
+
+    args = parse_args(
+        [
+            "--timeframe",
+            "1D",
+            "--start",
+            "2025-11-01",
+            "--end",
+            "2025-12-01",
+            "--tickers",
+            str(tickers_file),
+            "--marketlake-root",
+            str(marketlake_root),
+        ]
+    )
+
+    assert args.marketlake_root == marketlake_root
+
+
+def test_resolve_feature_build_runtime_prefers_cli_root(tmp_path: Path, monkeypatch) -> None:
+    settings = _settings(tmp_path)
+    cli_root = tmp_path / "cli-marketlake"
+    monkeypatch.setenv("MARKETLAKE_ROOT", str(tmp_path / "env-marketlake"))
+    args = parse_args(
+        [
+            "--timeframe",
+            "1D",
+            "--start",
+            "2025-11-01",
+            "--end",
+            "2025-12-01",
+            "--tickers",
+            "configs/tickers_50.txt",
+            "--marketlake-root",
+            str(cli_root),
+        ]
+    )
+
+    runtime = resolve_feature_build_runtime(args, settings)
+
+    assert runtime.settings.marketlake_root == cli_root
+    assert runtime.marketlake_root_source == "cli"
+    assert settings.marketlake_root == tmp_path / "marketlake"
+    assert runtime.config_resolution == {
+        "marketlake_root": {
+            "value": str(cli_root),
+            "source": "cli",
+        }
+    }
+
+
+def test_resolve_feature_build_runtime_keeps_environment_fallback(
+    tmp_path: Path, monkeypatch
+) -> None:
+    env_root = tmp_path / "env-marketlake"
+    settings = _settings(tmp_path)
+    settings = Settings(
+        marketlake_root=env_root,
+        features_root=settings.features_root,
+        artifacts_root=settings.artifacts_root,
+        duckdb_path=settings.duckdb_path,
+        log_level=settings.log_level,
+        default_timezone=settings.default_timezone,
+        paths_config={"marketlake_root": str(tmp_path / "config-marketlake")},
+        universe_config=settings.universe_config,
+        features_config=settings.features_config,
+    )
+    monkeypatch.setenv("MARKETLAKE_ROOT", str(env_root))
+    args = parse_args(
+        [
+            "--timeframe",
+            "1D",
+            "--start",
+            "2025-11-01",
+            "--end",
+            "2025-12-01",
+            "--tickers",
+            "configs/tickers_50.txt",
+        ]
+    )
+
+    runtime = resolve_feature_build_runtime(args, settings)
+
+    assert runtime.settings.marketlake_root == env_root
+    assert runtime.marketlake_root_source == "environment"
 
 
 def test_compute_missingness_summary() -> None:
@@ -132,6 +225,7 @@ def test_run_cli_dispatches_minute_pipeline_and_logs_metadata(
     tickers_file.write_text("AAPL\nMSFT\n", encoding="utf-8")
 
     settings = _settings(tmp_path)
+    monkeypatch.delenv("MARKETLAKE_ROOT", raising=False)
     used_partition = settings.marketlake_root / "bars_1m" / "symbol=AAPL" / "date=2025-11-01"
     used_partition.mkdir(parents=True, exist_ok=True)
     (used_partition / "part-0.parquet").write_text("stub", encoding="utf-8")
@@ -143,6 +237,7 @@ def test_run_cli_dispatches_minute_pipeline_and_logs_metadata(
             "symbols": symbols,
             "start_date": start_date,
             "end_date": end_date,
+            "paths_root": kwargs.get("paths").root,
             "qa_artifacts_root": kwargs.get("qa_artifacts_root"),
         }
         return _features_df()
@@ -165,6 +260,7 @@ def test_run_cli_dispatches_minute_pipeline_and_logs_metadata(
         "symbols": ["AAPL", "MSFT"],
         "start_date": "2025-11-01",
         "end_date": "2025-12-01",
+        "paths_root": settings.marketlake_root,
         "qa_artifacts_root": settings.artifacts_root / "qa" / "features",
     }
     assert payload["run_id"] == "run-minute"
@@ -172,8 +268,14 @@ def test_run_cli_dispatches_minute_pipeline_and_logs_metadata(
     assert payload["symbols_requested"] == ["AAPL", "MSFT"]
     assert payload["symbols_processed"] == ["AAPL", "MSFT"]
     assert payload["feature_row_count"] == 2
+    assert payload["marketlake_root"] == str(settings.marketlake_root)
+    assert payload["config_resolution"]["marketlake_root"] == {
+        "value": str(settings.marketlake_root),
+        "source": "paths_config",
+    }
     assert payload["input_partitions_used"] == [str(used_partition.resolve())]
     assert "Resolved MARKETLAKE_ROOT=" in caplog.text
+    assert "source=paths_config" in caplog.text
     assert "Resolved timeframe=1Min" in caplog.text
     assert "Input partitions used=" in caplog.text
     assert "Run ID=run-minute" in caplog.text
@@ -184,6 +286,7 @@ def test_run_cli_dispatches_daily_pipeline(tmp_path: Path, monkeypatch) -> None:
     tickers_file.write_text("AAPL\n", encoding="utf-8")
 
     settings = _settings(tmp_path)
+    monkeypatch.delenv("MARKETLAKE_ROOT", raising=False)
     calls: dict[str, object] = {}
 
     def fake_daily_pipeline(symbols, *, start_date=None, end_date=None, **kwargs):
@@ -191,6 +294,7 @@ def test_run_cli_dispatches_daily_pipeline(tmp_path: Path, monkeypatch) -> None:
             "symbols": symbols,
             "start_date": start_date,
             "end_date": end_date,
+            "paths_root": kwargs.get("paths").root,
             "qa_artifacts_root": kwargs.get("qa_artifacts_root"),
         }
         return _features_df().iloc[0:1].assign(timeframe="1D")
@@ -212,6 +316,7 @@ def test_run_cli_dispatches_daily_pipeline(tmp_path: Path, monkeypatch) -> None:
         "symbols": ["AAPL"],
         "start_date": "2025-11-01",
         "end_date": "2025-12-01",
+        "paths_root": settings.marketlake_root,
         "qa_artifacts_root": settings.artifacts_root / "qa" / "features",
     }
     assert summary_path == settings.artifacts_root / "feature_runs" / "run-daily" / "summary.json"
@@ -251,3 +356,76 @@ def test_run_cli_uses_env_when_paths_yaml_is_missing(tmp_path: Path, monkeypatch
     payload = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary_path == artifacts_root / "feature_runs" / "run-env-fallback" / "summary.json"
     assert payload["marketlake_root"] == str(marketlake_root)
+    assert payload["config_resolution"]["marketlake_root"]["source"] == "environment"
+
+
+def test_run_cli_marketlake_root_override_precedes_environment_and_config(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    tickers_file = tmp_path / "tickers.txt"
+    tickers_file.write_text("AAPL\n", encoding="utf-8")
+
+    settings = _settings(tmp_path)
+    cli_root = tmp_path / "cli-marketlake"
+    env_root = tmp_path / "env-marketlake"
+    config_root = tmp_path / "config-marketlake"
+    cli_partition = cli_root / "bars_daily" / "symbol=AAPL" / "year=2025"
+    cli_partition.mkdir(parents=True)
+    (cli_partition / "part-0.parquet").write_text("stub", encoding="utf-8")
+
+    settings = Settings(
+        marketlake_root=env_root,
+        features_root=settings.features_root,
+        artifacts_root=settings.artifacts_root,
+        duckdb_path=settings.duckdb_path,
+        log_level=settings.log_level,
+        default_timezone=settings.default_timezone,
+        paths_config={"marketlake_root": str(config_root)},
+        universe_config=settings.universe_config,
+        features_config=settings.features_config,
+    )
+
+    calls: dict[str, object] = {}
+
+    def fake_daily_pipeline(symbols, *, start_date=None, end_date=None, **kwargs):
+        calls["paths_root"] = kwargs.get("paths").root
+        return _features_df().iloc[0:1].assign(timeframe="1D")
+
+    monkeypatch.setenv("MARKETLAKE_ROOT", str(env_root))
+    monkeypatch.setattr("cli.build_features.Settings.load", lambda: settings)
+    monkeypatch.setattr("cli.build_features.run_daily_feature_pipeline", fake_daily_pipeline)
+    monkeypatch.setattr("cli.build_features.generate_run_id", lambda now=None: "run-cli-root")
+
+    caplog.set_level(logging.INFO)
+    summary_path = run_cli(
+        [
+            "--timeframe",
+            "1D",
+            "--start",
+            "2025-01-01",
+            "--end",
+            "2025-02-01",
+            "--tickers",
+            str(tickers_file),
+            "--marketlake-root",
+            str(cli_root),
+        ]
+    )
+
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert calls["paths_root"] == cli_root
+    assert payload["marketlake_root"] == str(cli_root)
+    assert payload["input_partitions_used"] == [str(cli_partition.resolve())]
+    assert payload["config_resolution"]["marketlake_root"] == {
+        "value": str(cli_root),
+        "source": "cli",
+    }
+    assert "Resolved MARKETLAKE_ROOT=" in caplog.text
+    assert "source=cli" in caplog.text
+    assert os.environ["MARKETLAKE_ROOT"] == str(env_root)
+
+
+def test_pyproject_registers_build_features_console_script() -> None:
+    pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'stratlake-build-features = "cli.build_features:main"' in pyproject_text


### PR DESCRIPTION
## Summary

This PR implements Issue #452 by improving feature-build ergonomics for notebooks, local shells, and installed package workflows.

It adds a packaged `stratlake-build-features` console script for the existing feature builder and introduces an explicit `--marketlake-root` runtime override so feature builds can point at a cell-local or shell-local curated MarketLake root without mutating persistent configuration.

## Changes

- Add `[project.scripts]` entry:

  ```toml
  stratlake-build-features = "cli.build_features:main"