### PR TITLE
M42 — Notebook Project Sessions and Filesystem Drive Persistence

### DIFF
--- a/docs/colab_project_sessions.md
+++ b/docs/colab_project_sessions.md
@@ -1,0 +1,277 @@
+# Colab Project Sessions
+
+## Purpose
+
+Use a StratLake project session in Colab or another cloud notebook when the
+notebook current working directory, StratLake project root, MarketLake root,
+and mounted Drive persistence root may all be different paths.
+
+The session makes those roots explicit without changing StratLake's
+artifact-first architecture. Session files and Drive copies are diagnostic
+notebook/session state. Canonical research evidence remains in StratLake
+artifact outputs such as manifests, metrics, summaries, inventories, and named
+workflow outputs.
+
+## Mental Model
+
+Keep these roots separate:
+
+- notebook CWD: where the notebook process happens to start
+- StratLake project root: the selected workspace for `.stratlake/`, `configs/`,
+  `artifacts/`, `docs/`, `contracts/`, and `notebooks/`
+- configs root: usually `PROJECT_ROOT / "configs"`
+- artifacts root: usually `PROJECT_ROOT / "artifacts"`
+- features root: usually `PROJECT_ROOT / "data" / "curated"` unless configured
+- external MarketLake root: a mounted or copied curated-data root outside the
+  StratLake project
+- mounted Drive persistence root: an optional local filesystem path used for
+  explicit backup/import/export snapshots
+
+Session-aware notebooks should resolve paths from the project session, not from
+the accidental notebook CWD.
+
+## Example Root Layout
+
+This Colab layout is an example, not a hard requirement:
+
+```text
+/content/stratlake
+  .stratlake/
+  configs/
+  artifacts/
+  docs/
+  notebooks/
+
+/content/fintech/data/curated
+  features_daily/
+  features_1m/
+  ...
+
+/content/drive/MyDrive/stratlake-demo
+  .stratlake/
+  configs/
+  artifacts/
+  data/
+```
+
+## Session-First Notebook Setup
+
+Install StratLake in the notebook environment. Use the package source that
+matches the work you are doing:
+
+```bash
+!python -m pip install stratlake-trade-engine
+```
+
+If you are running from a checked-out repository instead:
+
+```bash
+!python -m pip install -e .
+```
+
+Optionally mount Google Drive in Colab:
+
+```python
+from google.colab import drive
+
+drive.mount("/content/drive")
+```
+
+Define explicit roots in a notebook cell:
+
+```python
+from pathlib import Path
+
+PROJECT_ROOT = Path("/content/stratlake").resolve()
+MARKETLAKE_ROOT = Path("/content/fintech/data/curated").resolve()
+DRIVE_ROOT = Path("/content/drive/MyDrive/stratlake-demo").resolve()
+```
+
+Initialize the project session:
+
+```bash
+!stratlake-init-session \
+  --root /content/stratlake \
+  --project-name stratlake-demo \
+  --marketlake-root /content/fintech/data/curated \
+  --drive-root /content/drive/MyDrive/stratlake-demo
+```
+
+Use `stratlake-init-session` when you want workspace starter files plus
+`.stratlake/session.json` and `.stratlake/path_resolution.json`. Use
+`stratlake-init-notebook` only when you want the workspace layout and starter
+templates without session metadata.
+
+## Inspect Session Paths
+
+Load the session and resolve the important roots before running workflow cells:
+
+```python
+from src.session import load_session, resolve_session_paths
+
+session = load_session(PROJECT_ROOT)
+paths = resolve_session_paths(session)
+
+configs_root = paths["configs_root"].resolved_path
+artifacts_root = paths["artifacts_root"].resolved_path
+features_root = paths["features_root"].resolved_path
+marketlake_root = paths["marketlake_root"].resolved_path
+drive_root = paths["drive_root"].resolved_path
+```
+
+Each resolved path includes the serialized path, resolved absolute path, path
+kind, source/provenance, input value when relevant, and base path when relevant.
+The helpers do not mutate CWD, `.env`, `os.environ`, Drive files, or canonical
+artifacts.
+
+Resolution precedence is deterministic:
+
+1. explicit API/CLI overrides
+2. session metadata
+3. recorded environment-variable fallbacks
+4. starter defaults
+
+## Build Features With Explicit MarketLake Root
+
+Create or upload a ticker file under the project root:
+
+```python
+(PROJECT_ROOT / "configs" / "tickers_demo.txt").write_text("AAPL\nMSFT\n", encoding="utf-8")
+```
+
+Run the feature builder with an explicit MarketLake root so the notebook CWD is
+irrelevant:
+
+```bash
+!stratlake-build-features \
+  --timeframe 1D \
+  --start 2025-01-01 \
+  --end 2025-02-01 \
+  --tickers /content/stratlake/configs/tickers_demo.txt \
+  --marketlake-root /content/fintech/data/curated
+```
+
+The feature-run summary records the effective MarketLake root and its source
+under `config_resolution`.
+
+## Run Workflows From Session Configs
+
+Use explicit config paths from the project root. For example:
+
+```bash
+!stratlake-run-strategy \
+  --strategies-config /content/stratlake/configs/strategies.yml \
+  --strategy momentum_v1 \
+  --start 2025-01-01 \
+  --end 2025-02-01 \
+  --evaluation /content/stratlake/configs/evaluation.yml
+```
+
+Use notebooks to run established StratLake APIs or CLI-equivalent commands and
+inspect canonical outputs. Do not move strategy logic, validation decisions, or
+artifact schemas into notebook cells.
+
+## Export Snapshots To Mounted Drive
+
+Drive persistence is optional. The Drive root is treated as a mounted
+filesystem path. StratLake's persistence adapter uses no Google API, OAuth,
+credentials, or network access.
+
+Drive copies are explicit backup/import/export snapshots only. They are not
+canonical artifact state, a remote registry, or a second source of truth.
+
+Dry-run first:
+
+```bash
+!stratlake-session-export \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --include-artifacts \
+  --dry-run
+```
+
+Export configs, artifacts, and feature data:
+
+```bash
+!stratlake-session-export \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --include-artifacts \
+  --include-features
+```
+
+Feature data requires `--include-features`. Market data requires
+`--include-market-data`. Neither is included by broad config, docs, or artifact
+flags.
+
+Use `--operation-id` when you want distinct historical manifests instead of
+reusing `latest`:
+
+```bash
+!stratlake-session-export \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --include-artifacts \
+  --operation-id colab-run-001
+```
+
+Non-dry-run operations write a diagnostic, non-authoritative manifest under:
+
+```text
+artifacts/_derived/notebook_sessions/<operation>_<operation_id>/drive_sync_manifest.json
+```
+
+## Restore In A New Notebook Session
+
+Install the package, mount Drive if needed, define the same explicit roots, and
+initialize or recreate the local project directory. Then import selected
+snapshots:
+
+```bash
+!stratlake-session-import \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --include-artifacts \
+  --include-features
+```
+
+Import preserves existing files by default. Use `--force` only when you
+intentionally want selected import destinations overwritten:
+
+```bash
+!stratlake-session-import \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --force
+```
+
+## Safe Persistence Defaults
+
+The filesystem adapter excludes sensitive and noisy files by default:
+
+- `.env`
+- credentials
+- API keys and secrets
+- notebook checkpoints
+- caches
+- Python bytecode
+- temporary files
+
+Do not use Drive persistence as a credential workflow. Keep secrets outside
+session snapshots.
+
+## Command Guide
+
+- `stratlake-init-notebook`: workspace layout and starter templates only
+- `stratlake-init-session`: workspace layout plus `.stratlake/` session metadata
+- `stratlake-session-export`: explicit one-shot export to a mounted Drive path
+- `stratlake-session-import`: explicit one-shot import from a mounted Drive path
+
+All commands should be given explicit roots in Colab-style notebooks. The
+commands do not change notebook CWD, mutate `.env`, mutate `os.environ`, call
+Google APIs, or start background sync.

--- a/docs/m42_release_notes.md
+++ b/docs/m42_release_notes.md
@@ -1,0 +1,184 @@
+# M42 Release Notes - Notebook Project Sessions and Filesystem Drive Persistence
+
+Milestone title:
+`M42 - Notebook Project Sessions and Filesystem Drive Persistence`
+
+M42 branch:
+`feature/m42-notebook-project-sessions-drive-persistence`
+
+Candidate milestone release tag:
+`v0.42.0-notebook-project-sessions-drive-persistence`
+
+## Milestone Principle
+
+Notebook sessions should make project roots, configs, artifacts, and optional
+cloud persistence explicit without hiding execution behavior or turning backups
+into canonical state.
+
+## Summary
+
+M42 adds a deterministic notebook project-session layer for local notebooks,
+Colab, and other cloud notebook environments where the notebook CWD, StratLake
+project root, external MarketLake root, and mounted Drive root may differ.
+
+The milestone adds explicit session metadata, session-aware path helpers, a
+session-first bootstrap command, filesystem-only mounted-Drive import/export,
+and copy-friendly Colab documentation. These features improve notebook
+ergonomics while preserving StratLake's artifact-first architecture.
+
+## Scope Summary
+
+M42 covers:
+
+* deterministic notebook project-session contract
+* `.stratlake/session.json`
+* `.stratlake/path_resolution.json`
+* copied `configs/session.yml`
+* `stratlake-init-session`
+* session-aware path helpers:
+  `find_session_root`, `load_session`, `resolve_session_paths`, and
+  `write_path_resolution_report`
+* filesystem-only `stratlake-session-export`
+* filesystem-only `stratlake-session-import`
+* copied `docs/colab_project_sessions.md`
+* safe default excludes for session persistence
+* explicit feature and market-data persistence gates
+* deterministic validation and packaging checks
+
+M42 does not add a Google Drive API integration, OAuth, background sync, a
+remote registry, a remote metadata service, credential handling, live market
+data, or a new canonical artifact store.
+
+## User-Facing Commands
+
+Initialize a session-first notebook workspace:
+
+```bash
+stratlake-init-session --root ./stratlake-workspace --project-name stratlake-demo
+```
+
+Export selected session content to a mounted filesystem path:
+
+```bash
+stratlake-session-export --root ./stratlake-workspace --drive-root ./mounted-drive/stratlake-demo --include-configs --include-artifacts
+```
+
+Import selected session content from a mounted filesystem path:
+
+```bash
+stratlake-session-import --root ./stratlake-workspace --drive-root ./mounted-drive/stratlake-demo --include-configs
+```
+
+Feature data requires `--include-features`. Market data requires
+`--include-market-data`. Import preserves existing files unless `--force` is
+provided. Use `--dry-run` to inspect deterministic copy plans without copying
+files.
+
+## Notebook Pattern
+
+```python
+from pathlib import Path
+
+from src.session import load_session, resolve_session_paths
+
+PROJECT_ROOT = Path("/content/stratlake").resolve()
+
+session = load_session(PROJECT_ROOT)
+paths = resolve_session_paths(session)
+
+configs_root = paths["configs_root"].resolved_path
+artifacts_root = paths["artifacts_root"].resolved_path
+marketlake_root = paths["marketlake_root"].resolved_path
+drive_root = paths["drive_root"].resolved_path
+```
+
+The helpers do not mutate CWD, `.env`, `os.environ`, Drive files, package
+resources, or canonical artifacts.
+
+## Architecture Boundaries
+
+M42 preserves these boundaries:
+
+* session files are diagnostic notebook/session state
+* Drive copies are explicit persistence snapshots only
+* Drive manifests are diagnostic and non-authoritative
+* canonical artifacts remain authoritative
+* no Google API
+* no OAuth
+* no network dependency
+* no background sync
+* no remote registry
+* no second source of truth
+* no hidden CWD mutation
+* no `.env` or `os.environ` mutation
+
+## Validation Commands
+
+Focused M42 validation:
+
+```bash
+ruff check src/session src/cli tests
+pytest tests/test_init_notebook_workspace.py
+pytest tests/test_notebook_project_session.py
+pytest tests/test_init_session_cli.py
+pytest tests/test_session_path_resolution.py
+pytest tests/test_drive_persistence_adapter.py
+pytest tests/test_session_import_export.py
+pytest tests/test_m42_release_validation.py
+pytest tests/test_notebook_bootstrap_wheel_smoke.py
+```
+
+Docs/path validation:
+
+```bash
+pytest tests/test_docs_path_portability.py
+pytest tests/test_portable_paths.py
+pytest tests/test_m28_notebook_integration_examples.py
+```
+
+Release validation:
+
+```bash
+pytest
+python -m build
+```
+
+If `python -m build` emits the existing setuptools license-table deprecation
+warning, treat it as existing and non-blocking unless packaging metadata changes
+in the release branch.
+
+## Draft GitHub Release Notes
+
+Title:
+`M42 - Notebook Project Sessions and Filesystem Drive Persistence`
+
+Tag:
+`v0.42.0-notebook-project-sessions-drive-persistence`
+
+Branch:
+`feature/m42-notebook-project-sessions-drive-persistence`
+
+Summary:
+M42 adds deterministic notebook project sessions for StratLake workflows.
+Notebook and Colab users can initialize a project session, inspect resolved
+roots with provenance, and explicitly export/import selected session content to
+a mounted filesystem path such as Google Drive.
+
+Highlights:
+
+* Added `.stratlake/session.json` and `.stratlake/path_resolution.json`.
+* Added `stratlake-init-session`.
+* Added session-aware path helpers.
+* Added filesystem-only `stratlake-session-export`.
+* Added filesystem-only `stratlake-session-import`.
+* Added `configs/session.yml` as a copied starter template.
+* Added copied Colab project-session documentation.
+* Added safe default excludes for persistence snapshots.
+* Added explicit gates for feature and market-data persistence.
+* Added deterministic M42 validation and package-resource checks.
+
+Known boundaries:
+M42 does not add Google APIs, OAuth, network access, background sync, remote
+registries, remote metadata services, credential workflows, live market data,
+or a new canonical artifact store. Drive copies and manifests are
+non-authoritative snapshots.

--- a/docs/m42_release_validation_checklist.md
+++ b/docs/m42_release_validation_checklist.md
@@ -1,0 +1,234 @@
+# M42 Release Validation Checklist
+
+This checklist documents release-readiness checks for Milestone 42. It does not
+replace existing CI, milestone validation, or release automation.
+
+Milestone title:
+`M42 - Notebook Project Sessions and Filesystem Drive Persistence`
+
+M42 branch:
+`feature/m42-notebook-project-sessions-drive-persistence`
+
+Candidate milestone release tag:
+`v0.42.0-notebook-project-sessions-drive-persistence`
+
+## M42 Scope Recap
+
+M42 adds:
+
+* notebook project-session contract
+* session metadata files under `.stratlake/`
+* `stratlake-init-session`
+* session-aware path resolution helpers
+* filesystem-only mounted-Drive import/export
+* Colab project-session documentation
+* deterministic validation and packaging checks
+
+## Focused Validation
+
+Run Ruff over the M42-facing source and tests:
+
+```bash
+ruff check src/session src/cli tests
+```
+
+Run the focused M42 pytest slice:
+
+```bash
+pytest tests/test_init_notebook_workspace.py
+pytest tests/test_notebook_project_session.py
+pytest tests/test_init_session_cli.py
+pytest tests/test_session_path_resolution.py
+pytest tests/test_drive_persistence_adapter.py
+pytest tests/test_session_import_export.py
+pytest tests/test_m42_release_validation.py
+```
+
+Run the opt-in wheel smoke when the release environment is allowed to build and
+install a local wheel in a temporary virtual environment:
+
+```bash
+pytest tests/test_notebook_bootstrap_wheel_smoke.py
+```
+
+The wheel smoke may be skipped unless
+`STRATLAKE_RUN_NOTEBOOK_BOOTSTRAP_WHEEL_SMOKE=1` is set.
+
+## Session Contract Validation
+
+Confirm validation covers:
+
+* stable session schema version
+* `.stratlake/session.json` creation
+* `.stratlake/path_resolution.json` creation
+* project-internal POSIX-style relative serialization
+* external MarketLake root classification
+* optional Drive root classification
+* path source/provenance for resolved roots
+* no mutation of `.env`, `os.environ`, package resources, or canonical artifacts
+
+## Session Bootstrap CLI Validation
+
+Confirm validation covers:
+
+* notebook workspace initialization through `stratlake-init-session`
+* delegated starter-template copy behavior
+* copied `configs/session.yml`
+* copied `docs/colab_project_sessions.md`
+* no-overwrite-by-default behavior
+* `--force` refresh behavior for known templates and session metadata
+* clear failures for unsafe session metadata writes
+
+## Path-Resolution Validation
+
+Confirm validation covers:
+
+* `find_session_root`
+* `load_session`
+* `resolve_session_paths`
+* `write_path_resolution_report`
+* deterministic precedence:
+  explicit overrides, session metadata, environment-variable fallbacks, defaults
+* environment-variable provenance when a fallback is used
+* no hidden CWD mutation
+
+## Drive Filesystem Persistence Validation
+
+Confirm validation covers:
+
+* export dry-run behavior
+* export actual copy behavior
+* import roundtrip behavior
+* no-overwrite-by-default behavior
+* `--force` overwrite behavior
+* safe default excludes:
+  `.env`, credentials, secrets, API keys, notebook checkpoints, caches,
+  bytecode, and temporary files
+* feature data gated by `--include-features`
+* market data gated by `--include-market-data`
+* deterministic manifest ordering
+* non-authoritative manifest metadata
+
+## Docs And Resource Validation
+
+Run docs/path portability validation:
+
+```bash
+pytest tests/test_docs_path_portability.py
+pytest tests/test_portable_paths.py
+pytest tests/test_m28_notebook_integration_examples.py
+```
+
+If present in the checkout, also run:
+
+```bash
+pytest tests/test_docs_path_lint.py
+```
+
+Inspect these docs before tagging:
+
+* [Notebook Workspace Bootstrap](notebook_workspace_bootstrap.md)
+* [Notebook Integration](notebook_integration.md)
+* [Colab Project Sessions](colab_project_sessions.md)
+* [M42 Release Notes](m42_release_notes.md)
+
+Confirm:
+
+* Colab-specific `/content/...` paths are confined to Colab-scoped examples
+* no local Windows absolute paths appear in docs
+* no `file://` links appear in docs
+* no docs describe Drive copies as canonical artifacts
+* no docs imply Google API, OAuth, credentials, or network access
+* copied resource docs match release-facing guidance
+
+## Package Build Validation
+
+Run package build validation:
+
+```bash
+python -m build
+```
+
+Confirm packaged resources include:
+
+* `configs/session.yml`
+* `docs/notebook_integration.md`
+* `docs/colab_project_sessions.md`
+* existing notebook workspace starter resources
+
+Confirm installed entry points include:
+
+* `stratlake-init-session`
+* `stratlake-session-export`
+* `stratlake-session-import`
+
+If the build emits the existing setuptools license-table deprecation warning,
+record it as existing and non-blocking unless this branch changes packaging
+metadata.
+
+## Full Test Validation
+
+Run full pytest when practical:
+
+```bash
+pytest
+```
+
+No M42 test should require:
+
+* network access
+* Google Drive credentials
+* OAuth
+* a real mounted Drive
+* live market data
+* external services
+
+## Generated Output Hygiene
+
+Before merging:
+
+* confirm `git status --short` contains only intentional source/doc changes
+* confirm no generated `docs/examples/output/` directories are staged
+* confirm no `dist/`, `build/`, or `*.egg-info/` outputs are staged
+* confirm no local absolute paths appear in M42 docs
+* confirm no credentials, tokens, API keys, or passwords are staged
+
+## Known Non-Goals And Preserved Boundaries
+
+M42 does not implement:
+
+* Google API calls
+* OAuth
+* network access
+* background sync
+* daemon behavior
+* remote registries
+* remote metadata services
+* credential workflows
+* live market data dependency
+* hidden CWD mutation
+* `.env` mutation
+* `os.environ` mutation
+* canonical artifact schema changes beyond the diagnostic session metadata
+
+Confirm M42 keeps the artifact-first boundary intact:
+
+* session files are diagnostic notebook/session state
+* Drive copies are persistence snapshots only
+* Drive manifests are diagnostic and non-authoritative
+* canonical artifacts remain authoritative
+* no second source of truth is introduced
+
+## Release Tag Checklist
+
+Before creating `v0.42.0-notebook-project-sessions-drive-persistence`:
+
+* focused M42 validation is green
+* docs/path portability validation is green
+* package build validation is green
+* full pytest is green or any skipped tests are documented
+* release notes are final
+* generated output hygiene check is clean
+* branch name and tag candidate are still accurate
+
+Prepare GitHub Release notes from [M42 Release Notes](m42_release_notes.md).

--- a/docs/notebook_integration.md
+++ b/docs/notebook_integration.md
@@ -73,6 +73,26 @@ artifact outputs.
 Drive persistence intent as metadata only. It does not perform Google Drive
 sync, import, export, backup, OAuth, or API calls.
 
+Notebook cells can consume session metadata through path helpers:
+
+```python
+from src.session import find_session_root, load_session, resolve_session_paths
+
+root = find_session_root()
+session = load_session(root)
+paths = resolve_session_paths(session)
+
+configs_root = paths["configs_root"].resolved_path
+artifacts_root = paths["artifacts_root"].resolved_path
+marketlake_root = paths["marketlake_root"].resolved_path
+```
+
+`resolve_session_paths(...)` applies explicit overrides first, then session
+metadata, then environment-variable fallbacks such as `MARKETLAKE_ROOT`, and
+then starter defaults. Any environment fallback is recorded with provenance;
+the helpers do not mutate CWD, `.env`, `os.environ`, Drive files, or canonical
+artifacts.
+
 ## Existing Notebook Surface
 
 The public notebook-friendly execution surface is documented in

--- a/docs/notebook_integration.md
+++ b/docs/notebook_integration.md
@@ -43,6 +43,10 @@ See [`docs/notebook_workspace_bootstrap.md`](notebook_workspace_bootstrap.md)
 for command reference, installed CLI entry points, and package/workspace
 boundary guidance.
 
+For a copy-friendly Colab walkthrough that keeps notebook CWD, project root,
+external MarketLake root, and mounted Drive root explicit, see
+[`docs/colab_project_sessions.md`](colab_project_sessions.md).
+
 For session-first notebooks, use `stratlake-init-session`. It delegates to the
 same notebook bootstrap initializer, then writes `.stratlake/session.json` and
 `.stratlake/path_resolution.json`:
@@ -116,6 +120,9 @@ temporary files are excluded by default.
 Use `--dry-run` to see the deterministic plan without copying files. Import
 preserves existing files unless `--force` is supplied. Non-dry-run operations
 write a manifest under `artifacts/_derived/notebook_sessions/...`.
+
+Use `--operation-id` when you want distinct historical manifests instead of
+reusing `latest`.
 
 ## Existing Notebook Surface
 

--- a/docs/notebook_integration.md
+++ b/docs/notebook_integration.md
@@ -43,6 +43,19 @@ See [`docs/notebook_workspace_bootstrap.md`](notebook_workspace_bootstrap.md)
 for command reference, installed CLI entry points, and package/workspace
 boundary guidance.
 
+## Notebook Project Sessions
+
+Notebook project sessions make root selection explicit without becoming a
+second source of truth for artifacts. The `src.session` package can create
+`.stratlake/session.json` and `.stratlake/path_resolution.json` under a selected
+project root. Those files record the notebook CWD, StratLake project root,
+`configs/`, `artifacts/`, `data/curated` feature root, optional external
+MarketLake root, optional Drive root, and path-resolution provenance.
+
+Session metadata is diagnostic state for notebook ergonomics. Canonical
+workflow state remains in manifests, summaries, metrics, inventories, and named
+artifact outputs.
+
 ## Existing Notebook Surface
 
 The public notebook-friendly execution surface is documented in

--- a/docs/notebook_integration.md
+++ b/docs/notebook_integration.md
@@ -93,6 +93,30 @@ then starter defaults. Any environment fallback is recorded with provenance;
 the helpers do not mutate CWD, `.env`, `os.environ`, Drive files, or canonical
 artifacts.
 
+## Filesystem Drive Persistence
+
+Mounted Drive persistence is available through explicit one-shot filesystem
+copy commands:
+
+```powershell
+stratlake-session-export --root ./stratlake-notebooks --drive-root ./mounted-drive/stratlake-demo --include-configs
+stratlake-session-import --root ./stratlake-notebooks --drive-root ./mounted-drive/stratlake-demo --include-configs
+```
+
+The Drive root is a local filesystem path. StratLake does not use Google APIs,
+OAuth, credentials, network access, background sync, or automatic backup.
+Copies are persistence snapshots and remain non-authoritative.
+
+Session metadata is included by default. Configs, contracts, docs, artifacts,
+and derived artifacts are opt-in. Feature data requires `--include-features`;
+MarketLake data requires `--include-market-data`. `.env`, obvious
+credential/secret/API-key files, notebook checkpoints, caches, bytecode, and
+temporary files are excluded by default.
+
+Use `--dry-run` to see the deterministic plan without copying files. Import
+preserves existing files unless `--force` is supplied. Non-dry-run operations
+write a manifest under `artifacts/_derived/notebook_sessions/...`.
+
 ## Existing Notebook Surface
 
 The public notebook-friendly execution surface is documented in

--- a/docs/notebook_integration.md
+++ b/docs/notebook_integration.md
@@ -43,6 +43,19 @@ See [`docs/notebook_workspace_bootstrap.md`](notebook_workspace_bootstrap.md)
 for command reference, installed CLI entry points, and package/workspace
 boundary guidance.
 
+For session-first notebooks, use `stratlake-init-session`. It delegates to the
+same notebook bootstrap initializer, then writes `.stratlake/session.json` and
+`.stratlake/path_resolution.json`:
+
+```powershell
+stratlake-init-session --root ./stratlake-notebooks --project-name stratlake-demo
+```
+
+Use `stratlake-init-notebook` when you only need the workspace layout and
+starter templates. Use `stratlake-init-session` when the notebook CWD, project
+root, MarketLake root, or optional Drive root may differ and should be recorded
+explicitly.
+
 ## Notebook Project Sessions
 
 Notebook project sessions make root selection explicit without becoming a
@@ -55,6 +68,10 @@ MarketLake root, optional Drive root, and path-resolution provenance.
 Session metadata is diagnostic state for notebook ergonomics. Canonical
 workflow state remains in manifests, summaries, metrics, inventories, and named
 artifact outputs.
+
+`stratlake-init-session --enable-drive-persistence --drive-root ...` records
+Drive persistence intent as metadata only. It does not perform Google Drive
+sync, import, export, backup, OAuth, or API calls.
 
 ## Existing Notebook Surface
 

--- a/docs/notebook_integration.md
+++ b/docs/notebook_integration.md
@@ -124,6 +124,10 @@ write a manifest under `artifacts/_derived/notebook_sessions/...`.
 Use `--operation-id` when you want distinct historical manifests instead of
 reusing `latest`.
 
+For the M42 release scope, validation checklist, and architecture boundaries,
+see [`docs/m42_release_notes.md`](m42_release_notes.md) and
+[`docs/m42_release_validation_checklist.md`](m42_release_validation_checklist.md).
+
 ## Existing Notebook Surface
 
 The public notebook-friendly execution surface is documented in

--- a/docs/notebook_workspace_bootstrap.md
+++ b/docs/notebook_workspace_bootstrap.md
@@ -75,6 +75,52 @@ Existing files are preserved by default.
 The bundled package-resource templates are only the source for the initial copy. After copying,
 the local workspace files are user-owned and mutable.
 
+The starter config set includes `configs/session.yml`, a user-owned template
+for notebook project-session metadata. The bootstrap command only copies this
+template; it does not create session metadata or mutate canonical artifacts.
+
+## Notebook Project Session Contract
+
+M42.1 introduces a reusable session contract under `src.session` for notebooks
+and Colab-style workflows that need explicit roots. A project session records:
+
+- `schema_version`
+- `project_name`
+- notebook current working directory
+- StratLake project root
+- config, artifact, and feature roots
+- optional external MarketLake root
+- optional Drive persistence root
+- path kind and source/provenance for each resolved path
+
+When written, session metadata lives under the selected project root:
+
+- `.stratlake/session.json`
+- `.stratlake/path_resolution.json`
+
+These files are diagnostic session metadata, not canonical artifact state. They
+do not replace manifests, summaries, metrics, inventories, or named workflow
+outputs.
+
+Project-internal paths are serialized as portable POSIX-style relative paths
+where practical, such as `configs` or `data/curated`. External absolute paths,
+such as mounted Drive paths or external MarketLake roots, remain absolute and
+are marked as external so they are not mistaken for project-owned files.
+
+Minimal library usage:
+
+```python
+from src.session import create_notebook_project_session, write_session_files
+
+session = create_notebook_project_session(
+    project_name="stratlake-demo",
+    project_root="./stratlake-notebooks",
+    marketlake_root="../fintech/data/curated",
+    drive_root="/content/drive/MyDrive/stratlake-demo",
+)
+write_session_files(session)
+```
+
 ## Installed Commands
 
 The package now provides stable installed entry points for common workflows:

--- a/docs/notebook_workspace_bootstrap.md
+++ b/docs/notebook_workspace_bootstrap.md
@@ -35,6 +35,12 @@ Bootstrap a workspace at an explicit root:
 stratlake-init-notebook --root ./stratlake-notebooks
 ```
 
+Bootstrap a session-first workspace and write `.stratlake/` metadata:
+
+```powershell
+stratlake-init-session --root ./stratlake-notebooks --project-name stratlake-demo
+```
+
 Overwrite only copied starter templates:
 
 ```powershell
@@ -74,6 +80,11 @@ Curated starter files are copied from bundled package resources into the local w
 Existing files are preserved by default.
 The bundled package-resource templates are only the source for the initial copy. After copying,
 the local workspace files are user-owned and mutable.
+
+Use `stratlake-init-notebook` when you only want the workspace directories and
+starter templates. Use `stratlake-init-session` when a notebook or Colab-style
+environment also needs explicit session metadata that records the selected
+project root and path provenance.
 
 The starter config set includes `configs/session.yml`, a user-owned template
 for notebook project-session metadata. The bootstrap command only copies this
@@ -121,11 +132,37 @@ session = create_notebook_project_session(
 write_session_files(session)
 ```
 
+The installed `stratlake-init-session` command is a thin wrapper around the
+same behavior:
+
+```powershell
+stratlake-init-session `
+  --root ./stratlake-workspace `
+  --project-name stratlake-demo `
+  --marketlake-root ./fintech/data/curated
+```
+
+Optional Drive persistence metadata can be recorded for later M42 workflows:
+
+```powershell
+stratlake-init-session `
+  --root /content/stratlake `
+  --project-name stratlake-colab `
+  --marketlake-root /content/fintech/data/curated `
+  --drive-root /content/drive/MyDrive/stratlake-colab `
+  --enable-drive-persistence
+```
+
+`--enable-drive-persistence` records intent only. It does not sync, import,
+export, copy, or back up Drive files. Drive filesystem persistence belongs to
+later M42 work.
+
 ## Installed Commands
 
 The package now provides stable installed entry points for common workflows:
 
 - `stratlake-init-notebook`
+- `stratlake-init-session`
 - `stratlake-build-features`
 - `stratlake-run-strategy`
 - `stratlake-run-alpha`

--- a/docs/notebook_workspace_bootstrap.md
+++ b/docs/notebook_workspace_bootstrap.md
@@ -157,6 +157,55 @@ stratlake-init-session `
 export, copy, or back up Drive files. Drive filesystem persistence belongs to
 later M42 work.
 
+## Session-Aware Path Helpers
+
+Notebook and CLI code can find and consume the session metadata without relying
+on the active notebook CWD:
+
+```python
+from src.session import find_session_root, load_session, resolve_session_paths
+
+root = find_session_root()
+session = load_session(root)
+paths = resolve_session_paths(session)
+
+configs_root = paths["configs_root"].resolved_path
+artifacts_root = paths["artifacts_root"].resolved_path
+marketlake_root = paths["marketlake_root"].resolved_path
+```
+
+`find_session_root(start)` walks upward from `start` or `Path.cwd()` until it
+finds `.stratlake/session.json`. `load_session(root)` accepts either a project
+root or a path inside a project and validates the session schema before
+returning a structured session object.
+
+`resolve_session_paths(...)` uses deterministic precedence:
+
+1. explicit `overrides={...}`
+2. session metadata
+3. environment-variable fallbacks such as `MARKETLAKE_ROOT`, `ARTIFACTS_ROOT`,
+   and `FEATURES_ROOT`
+4. starter defaults
+
+Environment variables are only fallbacks and are recorded with
+`environment_variable` provenance when used. The helpers do not mutate CWD,
+`.env`, `os.environ`, package resources, Drive files, or canonical artifacts.
+
+Override example:
+
+```python
+paths = resolve_session_paths(
+    session,
+    overrides={
+        "marketlake_root": "/content/fintech/data/curated",
+        "artifacts_root": "artifacts/session-demo",
+    },
+)
+```
+
+Use `write_path_resolution_report(session, overrides=...)` to refresh
+`.stratlake/path_resolution.json` with the same deterministic path provenance.
+
 ## Installed Commands
 
 The package now provides stable installed entry points for common workflows:

--- a/docs/notebook_workspace_bootstrap.md
+++ b/docs/notebook_workspace_bootstrap.md
@@ -41,6 +41,9 @@ Bootstrap a session-first workspace and write `.stratlake/` metadata:
 stratlake-init-session --root ./stratlake-notebooks --project-name stratlake-demo
 ```
 
+For Colab and mounted-Drive notebooks, use the session-first flow in
+[`docs/colab_project_sessions.md`](colab_project_sessions.md).
+
 Overwrite only copied starter templates:
 
 ```powershell
@@ -142,7 +145,8 @@ stratlake-init-session `
   --marketlake-root ./fintech/data/curated
 ```
 
-Optional Drive persistence metadata can be recorded for later M42 workflows:
+Optional Drive persistence metadata can be recorded for explicit import/export
+workflows:
 
 ```powershell
 stratlake-init-session `
@@ -154,8 +158,8 @@ stratlake-init-session `
 ```
 
 `--enable-drive-persistence` records intent only. It does not sync, import,
-export, copy, or back up Drive files. Drive filesystem persistence belongs to
-later M42 work.
+export, copy, or back up Drive files. Use `stratlake-session-export` and
+`stratlake-session-import` for explicit one-shot filesystem snapshots.
 
 ## Session-Aware Path Helpers
 
@@ -267,6 +271,9 @@ artifacts/_derived/notebook_sessions/<operation>_<operation_id>/drive_sync_manif
 The manifest records the operation, roots, included categories, exclude rules,
 source and destination paths, relative path, category, size, SHA-256 hash,
 status, and skip reason when a destination is preserved.
+
+Use `--operation-id` when you want distinct historical manifests instead of
+reusing `latest`.
 
 ## Installed Commands
 

--- a/docs/notebook_workspace_bootstrap.md
+++ b/docs/notebook_workspace_bootstrap.md
@@ -275,6 +275,9 @@ status, and skip reason when a destination is preserved.
 Use `--operation-id` when you want distinct historical manifests instead of
 reusing `latest`.
 
+Release-facing validation for the full notebook-session stack is documented in
+[`docs/m42_release_validation_checklist.md`](m42_release_validation_checklist.md).
+
 ## Installed Commands
 
 The package now provides stable installed entry points for common workflows:

--- a/docs/notebook_workspace_bootstrap.md
+++ b/docs/notebook_workspace_bootstrap.md
@@ -206,12 +206,76 @@ paths = resolve_session_paths(
 Use `write_path_resolution_report(session, overrides=...)` to refresh
 `.stratlake/path_resolution.json` with the same deterministic path provenance.
 
+## Filesystem Drive Persistence
+
+M42.4 adds explicit filesystem import/export helpers for mounted Drive-style
+paths. The mounted Drive path is treated as a normal local filesystem path:
+there are no Google API calls, OAuth flows, credentials, network access,
+background watchers, or automatic sync.
+
+Exports and imports are persistence snapshots only. They are not canonical
+artifact state, not a remote registry, and not a second source of truth.
+
+Export selected configs and artifacts:
+
+```powershell
+stratlake-session-export `
+  --root ./stratlake-workspace `
+  --drive-root ./mounted-drive/stratlake-demo `
+  --include-configs `
+  --include-artifacts
+```
+
+Dry-run without copying files:
+
+```powershell
+stratlake-session-export `
+  --root ./stratlake-workspace `
+  --drive-root ./mounted-drive/stratlake-demo `
+  --include-configs `
+  --include-artifacts `
+  --dry-run
+```
+
+Import selected files without overwriting existing files:
+
+```powershell
+stratlake-session-import `
+  --root ./stratlake-workspace `
+  --drive-root ./mounted-drive/stratlake-demo `
+  --include-configs
+```
+
+Use `--force` to explicitly overwrite existing import destinations. Feature
+data is copied only with `--include-features`; MarketLake data is copied only
+with `--include-market-data`.
+
+Session metadata is included by default. Other categories are opt-in:
+`--include-configs`, `--include-contracts`, `--include-docs`,
+`--include-artifacts`, `--include-derived-artifacts`, `--include-features`,
+and `--include-market-data`.
+
+Default excludes prevent copying `.env`, obvious credentials/secrets/API-key
+files, notebook checkpoints, Python bytecode, caches, and temporary files.
+
+Each non-dry-run operation writes a non-authoritative manifest under:
+
+```text
+artifacts/_derived/notebook_sessions/<operation>_<operation_id>/drive_sync_manifest.json
+```
+
+The manifest records the operation, roots, included categories, exclude rules,
+source and destination paths, relative path, category, size, SHA-256 hash,
+status, and skip reason when a destination is preserved.
+
 ## Installed Commands
 
 The package now provides stable installed entry points for common workflows:
 
 - `stratlake-init-notebook`
 - `stratlake-init-session`
+- `stratlake-session-export`
+- `stratlake-session-import`
 - `stratlake-build-features`
 - `stratlake-run-strategy`
 - `stratlake-run-alpha`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dev = [
 [project.scripts]
 stratlake-init-notebook = "src.cli.init_notebook_workspace:main"
 stratlake-init-session = "src.cli.init_session:main"
+stratlake-session-export = "src.cli.session_export:main"
+stratlake-session-import = "src.cli.session_import:main"
 stratlake-build-features = "cli.build_features:main"
 stratlake-run-strategy = "src.cli.run_strategy:main"
 stratlake-run-alpha = "src.cli.run_alpha:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
 
 [project.scripts]
 stratlake-init-notebook = "src.cli.init_notebook_workspace:main"
+stratlake-init-session = "src.cli.init_session:main"
 stratlake-build-features = "cli.build_features:main"
 stratlake-run-strategy = "src.cli.run_strategy:main"
 stratlake-run-alpha = "src.cli.run_alpha:main"
@@ -67,6 +68,9 @@ include = ["src*", "cli*"]
 
 [tool.setuptools.package-data]
 "src.resources.notebook_workspace" = ["**/*"]
+
+[tool.setuptools.exclude-package-data]
+"*" = ["__pycache__/*", "**/__pycache__/*", "*.pyc", "**/*.pyc"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/cli/init_notebook_workspace.py
+++ b/src/cli/init_notebook_workspace.py
@@ -27,6 +27,7 @@ STARTER_DOCS: tuple[str, ...] = (
     "concurrency_and_idempotency.md",
     "cross_layer_validation.md",
     "catalog_notebook_ergonomics.md",
+    "colab_project_sessions.md",
     "examples/notebook_execution_api_examples.py",
 )
 

--- a/src/cli/init_notebook_workspace.py
+++ b/src/cli/init_notebook_workspace.py
@@ -14,6 +14,7 @@ STARTER_CONFIGS: tuple[str, ...] = (
     "portfolios.yml",
     "candidate_selection.yml",
     "review.yml",
+    "session.yml",
     "profiles/notebook.yml",
     "pipelines/scenario_matrix_pipeline.yml",
 )

--- a/src/cli/init_session.py
+++ b/src/cli/init_session.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Sequence
+
+from src.cli.init_notebook_workspace import initialize_notebook_workspace
+from src.session import create_notebook_project_session, write_session_files
+from src.session.io import PATH_RESOLUTION_FILE_NAME, SESSION_DIR_NAME, SESSION_FILE_NAME
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Initialize a StratLake notebook workspace and write deterministic "
+            "project-session metadata."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Target StratLake project root. Defaults to the current working directory.",
+    )
+    parser.add_argument(
+        "--project-name",
+        default=None,
+        help="Project name recorded in session metadata. Defaults to the root directory name.",
+    )
+    parser.add_argument(
+        "--marketlake-root",
+        default="data/curated",
+        help="MarketLake curated-data root to record for this session.",
+    )
+    parser.add_argument(
+        "--drive-root",
+        default=None,
+        help="Optional Google Drive or cloud persistence root to record as metadata only.",
+    )
+    parser.add_argument(
+        "--enable-drive-persistence",
+        action="store_true",
+        help=(
+            "Record Drive persistence intent in session metadata. This does not sync, "
+            "export, import, or copy Drive files."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Overwrite known starter templates through the notebook bootstrap and refresh "
+            "session metadata."
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.enable_drive_persistence and not args.drive_root:
+        parser.error("--enable-drive-persistence requires --drive-root")
+    return args
+
+
+def run_cli(argv: Sequence[str] | None = None) -> dict[str, object]:
+    args = parse_args(argv)
+    root = Path(args.root).expanduser().resolve()
+    _preflight_session_metadata(root, force=args.force)
+
+    bootstrap_summary = initialize_notebook_workspace(root, force=args.force)
+    session = create_notebook_project_session(
+        project_root=root,
+        project_name=args.project_name,
+        marketlake_root=args.marketlake_root,
+        drive_root=args.drive_root,
+        drive_persistence_enabled=args.enable_drive_persistence,
+    )
+    write_result = write_session_files(session, overwrite=args.force)
+    summary: dict[str, object] = {
+        "bootstrap": bootstrap_summary,
+        "session": session.to_dict(),
+        "session_path": write_result.session_path.as_posix(),
+        "path_resolution_path": write_result.path_resolution_path.as_posix(),
+        "drive_persistence_enabled": args.enable_drive_persistence,
+    }
+    print_summary(summary)
+    return summary
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        run_cli(argv)
+    except (
+        FileExistsError,
+        FileNotFoundError,
+        NotADirectoryError,
+        RuntimeError,
+        ValueError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def _preflight_session_metadata(root: Path, *, force: bool) -> None:
+    session_dir = (root / SESSION_DIR_NAME).resolve()
+    _ensure_under_root(session_dir, root)
+    session_path = (session_dir / SESSION_FILE_NAME).resolve()
+    resolution_path = (session_dir / PATH_RESOLUTION_FILE_NAME).resolve()
+    _ensure_under_root(session_path, root)
+    _ensure_under_root(resolution_path, root)
+    if force:
+        return
+
+    existing = [path for path in (session_path, resolution_path) if path.exists()]
+    if existing:
+        joined = ", ".join(path.as_posix() for path in existing)
+        raise FileExistsError(
+            "Session metadata already exists. Re-run with --force to refresh known "
+            f"session files: {joined}"
+        )
+
+
+def _ensure_under_root(path: Path, root: Path) -> None:
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Refusing to write session metadata outside project root: {path.as_posix()}"
+        ) from exc
+
+
+def print_summary(summary: dict[str, object]) -> None:
+    bootstrap = summary["bootstrap"]
+    session = summary["session"]
+
+    print(f"Initialized StratLake notebook session at: {bootstrap['root']}")
+    print(
+        "Template status: "
+        f"copied={len(bootstrap['copied'])}, "
+        f"overwritten={len(bootstrap['overwritten'])}, "
+        f"skipped={len(bootstrap['skipped'])}"
+    )
+    print("Resolved roots:")
+    for key in (
+        "project_root",
+        "configs_root",
+        "artifacts_root",
+        "features_root",
+        "marketlake_root",
+        "drive_root",
+    ):
+        if key in session:
+            value = session[key]
+            print(f"  {key}: {value['path']} ({value['kind']}, {value['source']})")
+    drive_persistence = session["drive_persistence"]
+    print(
+        "Drive persistence: "
+        f"{'enabled' if drive_persistence['enabled'] else 'disabled'} "
+        f"({drive_persistence['mode']})"
+    )
+    print("Session metadata:")
+    print(f"  session: {summary['session_path']}")
+    print(f"  path_resolution: {summary['path_resolution_path']}")
+    print("Next: open notebooks from this project root and pass explicit paths to StratLake APIs.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/session_copy_common.py
+++ b/src/cli/session_copy_common.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Sequence
+
+from src.session.drive_adapter import (
+    COPY_CATEGORIES,
+    SessionCopyResult,
+    export_session_to_drive,
+    import_session_from_drive,
+)
+
+CATEGORY_FLAGS = {
+    "configs": "--include-configs",
+    "contracts": "--include-contracts",
+    "docs": "--include-docs",
+    "artifacts": "--include-artifacts",
+    "derived_artifacts": "--include-derived-artifacts",
+    "features": "--include-features",
+    "market_data": "--include-market-data",
+    "session_metadata": "--include-session-metadata",
+}
+
+
+def build_parser(operation: str) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            f"{operation.title()} selected StratLake notebook-session files to or from "
+            "a mounted filesystem Drive root."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Local StratLake session root or a path inside it. Defaults to current directory.",
+    )
+    parser.add_argument(
+        "--drive-root",
+        default=None,
+        help="Mounted Drive/project root. If omitted, uses drive_root from session metadata.",
+    )
+    for category, flag in CATEGORY_FLAGS.items():
+        parser.add_argument(
+            flag,
+            action="store_true",
+            help=f"Include {category.replace('_', ' ')} in this explicit one-shot copy.",
+        )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan the copy without copying files. No manifest is written unless --write-manifest is set.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow overwriting existing destination files.",
+    )
+    parser.add_argument(
+        "--operation-id",
+        default="latest",
+        help="Deterministic manifest operation id. Defaults to 'latest'.",
+    )
+    parser.add_argument(
+        "--write-manifest",
+        action="store_true",
+        help="Write a manifest even for dry-runs.",
+    )
+    return parser
+
+
+def run_copy_cli(operation: str, argv: Sequence[str] | None = None) -> dict[str, object]:
+    parser = build_parser(operation)
+    args = parser.parse_args(argv)
+    categories = _selected_categories(args)
+    copy_fn = export_session_to_drive if operation == "export" else import_session_from_drive
+    result = copy_fn(
+        root=Path(args.root),
+        drive_root=args.drive_root,
+        include_categories=categories,
+        force=args.force,
+        dry_run=args.dry_run,
+        operation_id=args.operation_id,
+        write_manifest=True if args.write_manifest else None,
+    )
+    print_copy_summary(result)
+    return result.to_dict()
+
+
+def main_for_operation(operation: str, argv: Sequence[str] | None = None) -> int:
+    try:
+        run_copy_cli(operation, argv)
+    except (FileExistsError, FileNotFoundError, NotADirectoryError, RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def print_copy_summary(result: SessionCopyResult) -> None:
+    plan = result.plan
+    print(f"StratLake session {plan.operation}:")
+    print(f"  local_root: {plan.local_root.as_posix()}")
+    print(f"  drive_root: {plan.drive_root.as_posix()}")
+    print(f"  categories: {', '.join(plan.include_categories)}")
+    print(f"  dry_run: {str(plan.dry_run).lower()}")
+    print(f"  copied: {result.copied_count}")
+    print(f"  skipped: {result.skipped_count}")
+    print(f"  overwritten: {result.overwritten_count}")
+    if result.manifest_path is not None:
+        print(f"  manifest: {result.manifest_path.as_posix()}")
+
+
+def _selected_categories(args: argparse.Namespace) -> tuple[str, ...]:
+    selected = []
+    for category in COPY_CATEGORIES:
+        attr = f"include_{category}"
+        if getattr(args, attr):
+            selected.append(category)
+    return tuple(selected)

--- a/src/cli/session_export.py
+++ b/src/cli/session_export.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from src.cli.session_copy_common import main_for_operation, run_copy_cli
+
+
+def run_cli(argv: Sequence[str] | None = None) -> dict[str, object]:
+    return run_copy_cli("export", argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return main_for_operation("export", argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/session_import.py
+++ b/src/cli/session_import.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from src.cli.session_copy_common import main_for_operation, run_copy_cli
+
+
+def run_cli(argv: Sequence[str] | None = None) -> dict[str, object]:
+    return run_copy_cli("import", argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return main_for_operation("import", argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/resources/notebook_workspace/configs/session.yml
+++ b/src/resources/notebook_workspace/configs/session.yml
@@ -1,0 +1,19 @@
+# StratLake notebook project-session starter config.
+#
+# This file is copied into notebook workspaces as user-owned guidance. It is not
+# read automatically by M42.1 and is not canonical artifact state.
+
+project_name: stratlake-demo
+
+paths:
+  project_root: .
+  configs_root: configs
+  artifacts_root: artifacts
+  features_root: data/curated
+  marketlake_root: data/curated
+  drive_root: null
+
+notes:
+  - Keep project-internal paths relative where practical.
+  - Use explicit absolute paths only for external mounts such as Google Drive.
+  - Session metadata belongs under .stratlake/ and does not replace artifacts.

--- a/src/resources/notebook_workspace/docs/colab_project_sessions.md
+++ b/src/resources/notebook_workspace/docs/colab_project_sessions.md
@@ -1,0 +1,277 @@
+# Colab Project Sessions
+
+## Purpose
+
+Use a StratLake project session in Colab or another cloud notebook when the
+notebook current working directory, StratLake project root, MarketLake root,
+and mounted Drive persistence root may all be different paths.
+
+The session makes those roots explicit without changing StratLake's
+artifact-first architecture. Session files and Drive copies are diagnostic
+notebook/session state. Canonical research evidence remains in StratLake
+artifact outputs such as manifests, metrics, summaries, inventories, and named
+workflow outputs.
+
+## Mental Model
+
+Keep these roots separate:
+
+- notebook CWD: where the notebook process happens to start
+- StratLake project root: the selected workspace for `.stratlake/`, `configs/`,
+  `artifacts/`, `docs/`, `contracts/`, and `notebooks/`
+- configs root: usually `PROJECT_ROOT / "configs"`
+- artifacts root: usually `PROJECT_ROOT / "artifacts"`
+- features root: usually `PROJECT_ROOT / "data" / "curated"` unless configured
+- external MarketLake root: a mounted or copied curated-data root outside the
+  StratLake project
+- mounted Drive persistence root: an optional local filesystem path used for
+  explicit backup/import/export snapshots
+
+Session-aware notebooks should resolve paths from the project session, not from
+the accidental notebook CWD.
+
+## Example Root Layout
+
+This Colab layout is an example, not a hard requirement:
+
+```text
+/content/stratlake
+  .stratlake/
+  configs/
+  artifacts/
+  docs/
+  notebooks/
+
+/content/fintech/data/curated
+  features_daily/
+  features_1m/
+  ...
+
+/content/drive/MyDrive/stratlake-demo
+  .stratlake/
+  configs/
+  artifacts/
+  data/
+```
+
+## Session-First Notebook Setup
+
+Install StratLake in the notebook environment. Use the package source that
+matches the work you are doing:
+
+```bash
+!python -m pip install stratlake-trade-engine
+```
+
+If you are running from a checked-out repository instead:
+
+```bash
+!python -m pip install -e .
+```
+
+Optionally mount Google Drive in Colab:
+
+```python
+from google.colab import drive
+
+drive.mount("/content/drive")
+```
+
+Define explicit roots in a notebook cell:
+
+```python
+from pathlib import Path
+
+PROJECT_ROOT = Path("/content/stratlake").resolve()
+MARKETLAKE_ROOT = Path("/content/fintech/data/curated").resolve()
+DRIVE_ROOT = Path("/content/drive/MyDrive/stratlake-demo").resolve()
+```
+
+Initialize the project session:
+
+```bash
+!stratlake-init-session \
+  --root /content/stratlake \
+  --project-name stratlake-demo \
+  --marketlake-root /content/fintech/data/curated \
+  --drive-root /content/drive/MyDrive/stratlake-demo
+```
+
+Use `stratlake-init-session` when you want workspace starter files plus
+`.stratlake/session.json` and `.stratlake/path_resolution.json`. Use
+`stratlake-init-notebook` only when you want the workspace layout and starter
+templates without session metadata.
+
+## Inspect Session Paths
+
+Load the session and resolve the important roots before running workflow cells:
+
+```python
+from src.session import load_session, resolve_session_paths
+
+session = load_session(PROJECT_ROOT)
+paths = resolve_session_paths(session)
+
+configs_root = paths["configs_root"].resolved_path
+artifacts_root = paths["artifacts_root"].resolved_path
+features_root = paths["features_root"].resolved_path
+marketlake_root = paths["marketlake_root"].resolved_path
+drive_root = paths["drive_root"].resolved_path
+```
+
+Each resolved path includes the serialized path, resolved absolute path, path
+kind, source/provenance, input value when relevant, and base path when relevant.
+The helpers do not mutate CWD, `.env`, `os.environ`, Drive files, or canonical
+artifacts.
+
+Resolution precedence is deterministic:
+
+1. explicit API/CLI overrides
+2. session metadata
+3. recorded environment-variable fallbacks
+4. starter defaults
+
+## Build Features With Explicit MarketLake Root
+
+Create or upload a ticker file under the project root:
+
+```python
+(PROJECT_ROOT / "configs" / "tickers_demo.txt").write_text("AAPL\nMSFT\n", encoding="utf-8")
+```
+
+Run the feature builder with an explicit MarketLake root so the notebook CWD is
+irrelevant:
+
+```bash
+!stratlake-build-features \
+  --timeframe 1D \
+  --start 2025-01-01 \
+  --end 2025-02-01 \
+  --tickers /content/stratlake/configs/tickers_demo.txt \
+  --marketlake-root /content/fintech/data/curated
+```
+
+The feature-run summary records the effective MarketLake root and its source
+under `config_resolution`.
+
+## Run Workflows From Session Configs
+
+Use explicit config paths from the project root. For example:
+
+```bash
+!stratlake-run-strategy \
+  --strategies-config /content/stratlake/configs/strategies.yml \
+  --strategy momentum_v1 \
+  --start 2025-01-01 \
+  --end 2025-02-01 \
+  --evaluation /content/stratlake/configs/evaluation.yml
+```
+
+Use notebooks to run established StratLake APIs or CLI-equivalent commands and
+inspect canonical outputs. Do not move strategy logic, validation decisions, or
+artifact schemas into notebook cells.
+
+## Export Snapshots To Mounted Drive
+
+Drive persistence is optional. The Drive root is treated as a mounted
+filesystem path. StratLake's persistence adapter uses no Google API, OAuth,
+credentials, or network access.
+
+Drive copies are explicit backup/import/export snapshots only. They are not
+canonical artifact state, a remote registry, or a second source of truth.
+
+Dry-run first:
+
+```bash
+!stratlake-session-export \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --include-artifacts \
+  --dry-run
+```
+
+Export configs, artifacts, and feature data:
+
+```bash
+!stratlake-session-export \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --include-artifacts \
+  --include-features
+```
+
+Feature data requires `--include-features`. Market data requires
+`--include-market-data`. Neither is included by broad config, docs, or artifact
+flags.
+
+Use `--operation-id` when you want distinct historical manifests instead of
+reusing `latest`:
+
+```bash
+!stratlake-session-export \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --include-artifacts \
+  --operation-id colab-run-001
+```
+
+Non-dry-run operations write a diagnostic, non-authoritative manifest under:
+
+```text
+artifacts/_derived/notebook_sessions/<operation>_<operation_id>/drive_sync_manifest.json
+```
+
+## Restore In A New Notebook Session
+
+Install the package, mount Drive if needed, define the same explicit roots, and
+initialize or recreate the local project directory. Then import selected
+snapshots:
+
+```bash
+!stratlake-session-import \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --include-artifacts \
+  --include-features
+```
+
+Import preserves existing files by default. Use `--force` only when you
+intentionally want selected import destinations overwritten:
+
+```bash
+!stratlake-session-import \
+  --root /content/stratlake \
+  --drive-root /content/drive/MyDrive/stratlake-demo \
+  --include-configs \
+  --force
+```
+
+## Safe Persistence Defaults
+
+The filesystem adapter excludes sensitive and noisy files by default:
+
+- `.env`
+- credentials
+- API keys and secrets
+- notebook checkpoints
+- caches
+- Python bytecode
+- temporary files
+
+Do not use Drive persistence as a credential workflow. Keep secrets outside
+session snapshots.
+
+## Command Guide
+
+- `stratlake-init-notebook`: workspace layout and starter templates only
+- `stratlake-init-session`: workspace layout plus `.stratlake/` session metadata
+- `stratlake-session-export`: explicit one-shot export to a mounted Drive path
+- `stratlake-session-import`: explicit one-shot import from a mounted Drive path
+
+All commands should be given explicit roots in Colab-style notebooks. The
+commands do not change notebook CWD, mutate `.env`, mutate `os.environ`, call
+Google APIs, or start background sync.

--- a/src/resources/notebook_workspace/docs/notebook_integration.md
+++ b/src/resources/notebook_workspace/docs/notebook_integration.md
@@ -73,6 +73,26 @@ artifact outputs.
 Drive persistence intent as metadata only. It does not perform Google Drive
 sync, import, export, backup, OAuth, or API calls.
 
+Notebook cells can consume session metadata through path helpers:
+
+```python
+from src.session import find_session_root, load_session, resolve_session_paths
+
+root = find_session_root()
+session = load_session(root)
+paths = resolve_session_paths(session)
+
+configs_root = paths["configs_root"].resolved_path
+artifacts_root = paths["artifacts_root"].resolved_path
+marketlake_root = paths["marketlake_root"].resolved_path
+```
+
+`resolve_session_paths(...)` applies explicit overrides first, then session
+metadata, then environment-variable fallbacks such as `MARKETLAKE_ROOT`, and
+then starter defaults. Any environment fallback is recorded with provenance;
+the helpers do not mutate CWD, `.env`, `os.environ`, Drive files, or canonical
+artifacts.
+
 ## Existing Notebook Surface
 
 The public notebook-friendly execution surface is documented in

--- a/src/resources/notebook_workspace/docs/notebook_integration.md
+++ b/src/resources/notebook_workspace/docs/notebook_integration.md
@@ -43,6 +43,10 @@ See [`docs/notebook_workspace_bootstrap.md`](notebook_workspace_bootstrap.md)
 for command reference, installed CLI entry points, and package/workspace
 boundary guidance.
 
+For a copy-friendly Colab walkthrough that keeps notebook CWD, project root,
+external MarketLake root, and mounted Drive root explicit, see
+[`docs/colab_project_sessions.md`](colab_project_sessions.md).
+
 For session-first notebooks, use `stratlake-init-session`. It delegates to the
 same notebook bootstrap initializer, then writes `.stratlake/session.json` and
 `.stratlake/path_resolution.json`:
@@ -116,6 +120,9 @@ temporary files are excluded by default.
 Use `--dry-run` to see the deterministic plan without copying files. Import
 preserves existing files unless `--force` is supplied. Non-dry-run operations
 write a manifest under `artifacts/_derived/notebook_sessions/...`.
+
+Use `--operation-id` when you want distinct historical manifests instead of
+reusing `latest`.
 
 ## Existing Notebook Surface
 

--- a/src/resources/notebook_workspace/docs/notebook_integration.md
+++ b/src/resources/notebook_workspace/docs/notebook_integration.md
@@ -43,6 +43,19 @@ See [`docs/notebook_workspace_bootstrap.md`](notebook_workspace_bootstrap.md)
 for command reference, installed CLI entry points, and package/workspace
 boundary guidance.
 
+## Notebook Project Sessions
+
+Notebook project sessions make root selection explicit without becoming a
+second source of truth for artifacts. The `src.session` package can create
+`.stratlake/session.json` and `.stratlake/path_resolution.json` under a selected
+project root. Those files record the notebook CWD, StratLake project root,
+`configs/`, `artifacts/`, `data/curated` feature root, optional external
+MarketLake root, optional Drive root, and path-resolution provenance.
+
+Session metadata is diagnostic state for notebook ergonomics. Canonical
+workflow state remains in manifests, summaries, metrics, inventories, and named
+artifact outputs.
+
 ## Existing Notebook Surface
 
 The public notebook-friendly execution surface is documented in

--- a/src/resources/notebook_workspace/docs/notebook_integration.md
+++ b/src/resources/notebook_workspace/docs/notebook_integration.md
@@ -93,6 +93,30 @@ then starter defaults. Any environment fallback is recorded with provenance;
 the helpers do not mutate CWD, `.env`, `os.environ`, Drive files, or canonical
 artifacts.
 
+## Filesystem Drive Persistence
+
+Mounted Drive persistence is available through explicit one-shot filesystem
+copy commands:
+
+```powershell
+stratlake-session-export --root ./stratlake-notebooks --drive-root ./mounted-drive/stratlake-demo --include-configs
+stratlake-session-import --root ./stratlake-notebooks --drive-root ./mounted-drive/stratlake-demo --include-configs
+```
+
+The Drive root is a local filesystem path. StratLake does not use Google APIs,
+OAuth, credentials, network access, background sync, or automatic backup.
+Copies are persistence snapshots and remain non-authoritative.
+
+Session metadata is included by default. Configs, contracts, docs, artifacts,
+and derived artifacts are opt-in. Feature data requires `--include-features`;
+MarketLake data requires `--include-market-data`. `.env`, obvious
+credential/secret/API-key files, notebook checkpoints, caches, bytecode, and
+temporary files are excluded by default.
+
+Use `--dry-run` to see the deterministic plan without copying files. Import
+preserves existing files unless `--force` is supplied. Non-dry-run operations
+write a manifest under `artifacts/_derived/notebook_sessions/...`.
+
 ## Existing Notebook Surface
 
 The public notebook-friendly execution surface is documented in

--- a/src/resources/notebook_workspace/docs/notebook_integration.md
+++ b/src/resources/notebook_workspace/docs/notebook_integration.md
@@ -43,6 +43,19 @@ See [`docs/notebook_workspace_bootstrap.md`](notebook_workspace_bootstrap.md)
 for command reference, installed CLI entry points, and package/workspace
 boundary guidance.
 
+For session-first notebooks, use `stratlake-init-session`. It delegates to the
+same notebook bootstrap initializer, then writes `.stratlake/session.json` and
+`.stratlake/path_resolution.json`:
+
+```powershell
+stratlake-init-session --root ./stratlake-notebooks --project-name stratlake-demo
+```
+
+Use `stratlake-init-notebook` when you only need the workspace layout and
+starter templates. Use `stratlake-init-session` when the notebook CWD, project
+root, MarketLake root, or optional Drive root may differ and should be recorded
+explicitly.
+
 ## Notebook Project Sessions
 
 Notebook project sessions make root selection explicit without becoming a
@@ -55,6 +68,10 @@ MarketLake root, optional Drive root, and path-resolution provenance.
 Session metadata is diagnostic state for notebook ergonomics. Canonical
 workflow state remains in manifests, summaries, metrics, inventories, and named
 artifact outputs.
+
+`stratlake-init-session --enable-drive-persistence --drive-root ...` records
+Drive persistence intent as metadata only. It does not perform Google Drive
+sync, import, export, backup, OAuth, or API calls.
 
 ## Existing Notebook Surface
 

--- a/src/session/__init__.py
+++ b/src/session/__init__.py
@@ -8,6 +8,15 @@ from src.session.contracts import (
     ResolvedSessionPath,
     create_notebook_project_session,
 )
+from src.session.drive_adapter import (
+    SessionCopyItem,
+    SessionCopyPlan,
+    SessionCopyResult,
+    export_session_to_drive,
+    import_session_from_drive,
+    plan_session_copy,
+    write_drive_sync_manifest,
+)
 from src.session.io import SessionWriteResult, write_session_files
 from src.session.paths import (
     find_session_root,
@@ -22,11 +31,18 @@ __all__ = [
     "PathResolutionReport",
     "PathSource",
     "ResolvedSessionPath",
+    "SessionCopyItem",
+    "SessionCopyPlan",
+    "SessionCopyResult",
     "SessionWriteResult",
     "create_notebook_project_session",
+    "export_session_to_drive",
     "find_session_root",
+    "import_session_from_drive",
     "load_session",
+    "plan_session_copy",
     "resolve_session_paths",
+    "write_drive_sync_manifest",
     "write_path_resolution_report",
     "write_session_files",
 ]

--- a/src/session/__init__.py
+++ b/src/session/__init__.py
@@ -1,0 +1,22 @@
+"""Notebook project-session contracts for StratLake workflows."""
+
+from src.session.contracts import (
+    NotebookProjectSession,
+    PathKind,
+    PathResolutionReport,
+    PathSource,
+    ResolvedSessionPath,
+    create_notebook_project_session,
+)
+from src.session.io import SessionWriteResult, write_session_files
+
+__all__ = [
+    "NotebookProjectSession",
+    "PathKind",
+    "PathResolutionReport",
+    "PathSource",
+    "ResolvedSessionPath",
+    "SessionWriteResult",
+    "create_notebook_project_session",
+    "write_session_files",
+]

--- a/src/session/__init__.py
+++ b/src/session/__init__.py
@@ -9,6 +9,12 @@ from src.session.contracts import (
     create_notebook_project_session,
 )
 from src.session.io import SessionWriteResult, write_session_files
+from src.session.paths import (
+    find_session_root,
+    load_session,
+    resolve_session_paths,
+    write_path_resolution_report,
+)
 
 __all__ = [
     "NotebookProjectSession",
@@ -18,5 +24,9 @@ __all__ = [
     "ResolvedSessionPath",
     "SessionWriteResult",
     "create_notebook_project_session",
+    "find_session_root",
+    "load_session",
+    "resolve_session_paths",
+    "write_path_resolution_report",
     "write_session_files",
 ]

--- a/src/session/contracts.py
+++ b/src/session/contracts.py
@@ -84,6 +84,7 @@ class NotebookProjectSession:
     features_root: ResolvedSessionPath
     marketlake_root: ResolvedSessionPath
     drive_root: ResolvedSessionPath | None = None
+    drive_persistence_enabled: bool = False
 
     def paths(self) -> dict[str, ResolvedSessionPath]:
         values = {
@@ -111,6 +112,10 @@ class NotebookProjectSession:
         }
         if self.drive_root is not None:
             data["drive_root"] = self.drive_root.to_session_dict()
+        data["drive_persistence"] = {
+            "enabled": self.drive_persistence_enabled,
+            "mode": "metadata_only",
+        }
         return data
 
     def resolution_report(self) -> PathResolutionReport:
@@ -131,6 +136,7 @@ def create_notebook_project_session(
     features_root: Path | str = DEFAULT_FEATURES_ROOT,
     marketlake_root: Path | str = DEFAULT_MARKETLAKE_ROOT,
     drive_root: Path | str | None = None,
+    drive_persistence_enabled: bool = False,
 ) -> NotebookProjectSession:
     root_input = Path(project_root).expanduser()
     resolved_project_root = root_input.resolve()
@@ -206,6 +212,7 @@ def create_notebook_project_session(
             input_path=str(marketlake_root),
         ),
         drive_root=drive_root_path,
+        drive_persistence_enabled=drive_persistence_enabled,
     )
 
 

--- a/src/session/contracts.py
+++ b/src/session/contracts.py
@@ -21,12 +21,15 @@ class PathKind(str, Enum):
 class PathSource(str, Enum):
     CURRENT_WORKING_DIRECTORY = "current_working_directory"
     DEFAULT = "default"
+    ENVIRONMENT_VARIABLE = "environment_variable"
     EXPLICIT_ARTIFACTS_ROOT = "explicit_artifacts_root"
     EXPLICIT_CONFIGS_ROOT = "explicit_configs_root"
     EXPLICIT_DRIVE_ROOT = "explicit_drive_root"
     EXPLICIT_FEATURES_ROOT = "explicit_features_root"
     EXPLICIT_MARKETLAKE_ROOT = "explicit_marketlake_root"
+    EXPLICIT_OVERRIDE = "explicit_override"
     EXPLICIT_ROOT = "explicit_root"
+    SESSION_METADATA = "session_metadata"
 
 
 @dataclass(frozen=True)

--- a/src/session/contracts.py
+++ b/src/session/contracts.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Mapping
+
+SESSION_SCHEMA_VERSION = 1
+DEFAULT_CONFIGS_ROOT = "configs"
+DEFAULT_ARTIFACTS_ROOT = "artifacts"
+DEFAULT_FEATURES_ROOT = "data/curated"
+DEFAULT_MARKETLAKE_ROOT = "data/curated"
+
+
+class PathKind(str, Enum):
+    PROJECT_INTERNAL = "project_internal"
+    EXTERNAL_ABSOLUTE = "external_absolute"
+    EXTERNAL_OR_PROJECT_RELATIVE = "external_or_project_relative"
+
+
+class PathSource(str, Enum):
+    CURRENT_WORKING_DIRECTORY = "current_working_directory"
+    DEFAULT = "default"
+    EXPLICIT_ARTIFACTS_ROOT = "explicit_artifacts_root"
+    EXPLICIT_CONFIGS_ROOT = "explicit_configs_root"
+    EXPLICIT_DRIVE_ROOT = "explicit_drive_root"
+    EXPLICIT_FEATURES_ROOT = "explicit_features_root"
+    EXPLICIT_MARKETLAKE_ROOT = "explicit_marketlake_root"
+    EXPLICIT_ROOT = "explicit_root"
+
+
+@dataclass(frozen=True)
+class ResolvedSessionPath:
+    path: str
+    kind: PathKind
+    source: PathSource
+    resolved_path: str
+    input_path: str | None = None
+    base: str | None = None
+
+    def to_session_dict(self) -> dict[str, str]:
+        return {
+            "path": self.path,
+            "kind": self.kind.value,
+            "source": self.source.value,
+        }
+
+    def to_resolution_dict(self) -> dict[str, str | None]:
+        return {
+            "input_path": self.input_path,
+            "path": self.path,
+            "kind": self.kind.value,
+            "source": self.source.value,
+            "base": self.base,
+            "resolved_path": self.resolved_path,
+        }
+
+
+@dataclass(frozen=True)
+class PathResolutionReport:
+    schema_version: int
+    project_name: str
+    paths: Mapping[str, ResolvedSessionPath]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "project_name": self.project_name,
+            "paths": {
+                name: resolved.to_resolution_dict()
+                for name, resolved in self.paths.items()
+            },
+        }
+
+
+@dataclass(frozen=True)
+class NotebookProjectSession:
+    schema_version: int
+    project_name: str
+    notebook_cwd: ResolvedSessionPath
+    project_root: ResolvedSessionPath
+    configs_root: ResolvedSessionPath
+    artifacts_root: ResolvedSessionPath
+    features_root: ResolvedSessionPath
+    marketlake_root: ResolvedSessionPath
+    drive_root: ResolvedSessionPath | None = None
+
+    def paths(self) -> dict[str, ResolvedSessionPath]:
+        values = {
+            "notebook_cwd": self.notebook_cwd,
+            "project_root": self.project_root,
+            "configs_root": self.configs_root,
+            "artifacts_root": self.artifacts_root,
+            "features_root": self.features_root,
+            "marketlake_root": self.marketlake_root,
+        }
+        if self.drive_root is not None:
+            values["drive_root"] = self.drive_root
+        return values
+
+    def to_dict(self) -> dict[str, object]:
+        data: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "project_name": self.project_name,
+            "notebook_cwd": self.notebook_cwd.to_session_dict(),
+            "project_root": self.project_root.to_session_dict(),
+            "configs_root": self.configs_root.to_session_dict(),
+            "artifacts_root": self.artifacts_root.to_session_dict(),
+            "features_root": self.features_root.to_session_dict(),
+            "marketlake_root": self.marketlake_root.to_session_dict(),
+        }
+        if self.drive_root is not None:
+            data["drive_root"] = self.drive_root.to_session_dict()
+        return data
+
+    def resolution_report(self) -> PathResolutionReport:
+        return PathResolutionReport(
+            schema_version=self.schema_version,
+            project_name=self.project_name,
+            paths=self.paths(),
+        )
+
+
+def create_notebook_project_session(
+    *,
+    project_root: Path | str,
+    project_name: str | None = None,
+    notebook_cwd: Path | str | None = None,
+    configs_root: Path | str = DEFAULT_CONFIGS_ROOT,
+    artifacts_root: Path | str = DEFAULT_ARTIFACTS_ROOT,
+    features_root: Path | str = DEFAULT_FEATURES_ROOT,
+    marketlake_root: Path | str = DEFAULT_MARKETLAKE_ROOT,
+    drive_root: Path | str | None = None,
+) -> NotebookProjectSession:
+    root_input = Path(project_root).expanduser()
+    resolved_project_root = root_input.resolve()
+    effective_project_name = project_name or resolved_project_root.name
+    effective_notebook_cwd = Path.cwd() if notebook_cwd is None else Path(notebook_cwd)
+
+    notebook_cwd_path = _resolve_session_path(
+        value=effective_notebook_cwd,
+        project_root=resolved_project_root,
+        source=PathSource.CURRENT_WORKING_DIRECTORY,
+        input_path=None if notebook_cwd is None else str(notebook_cwd),
+    )
+    project_root_path = ResolvedSessionPath(
+        path=".",
+        kind=PathKind.PROJECT_INTERNAL,
+        source=PathSource.EXPLICIT_ROOT,
+        input_path=str(project_root),
+        base=None,
+        resolved_path=resolved_project_root.as_posix(),
+    )
+    drive_root_path = None
+    if drive_root is not None:
+        drive_root_path = _resolve_session_path(
+            value=drive_root,
+            project_root=resolved_project_root,
+            source=PathSource.EXPLICIT_DRIVE_ROOT,
+            input_path=str(drive_root),
+        )
+
+    return NotebookProjectSession(
+        schema_version=SESSION_SCHEMA_VERSION,
+        project_name=effective_project_name,
+        notebook_cwd=notebook_cwd_path,
+        project_root=project_root_path,
+        configs_root=_resolve_session_path(
+            value=configs_root,
+            project_root=resolved_project_root,
+            source=_source_for_path(
+                value=configs_root,
+                default=DEFAULT_CONFIGS_ROOT,
+                explicit_source=PathSource.EXPLICIT_CONFIGS_ROOT,
+            ),
+            input_path=str(configs_root),
+        ),
+        artifacts_root=_resolve_session_path(
+            value=artifacts_root,
+            project_root=resolved_project_root,
+            source=_source_for_path(
+                value=artifacts_root,
+                default=DEFAULT_ARTIFACTS_ROOT,
+                explicit_source=PathSource.EXPLICIT_ARTIFACTS_ROOT,
+            ),
+            input_path=str(artifacts_root),
+        ),
+        features_root=_resolve_session_path(
+            value=features_root,
+            project_root=resolved_project_root,
+            source=_source_for_path(
+                value=features_root,
+                default=DEFAULT_FEATURES_ROOT,
+                explicit_source=PathSource.EXPLICIT_FEATURES_ROOT,
+            ),
+            input_path=str(features_root),
+        ),
+        marketlake_root=_resolve_session_path(
+            value=marketlake_root,
+            project_root=resolved_project_root,
+            source=_source_for_path(
+                value=marketlake_root,
+                default=DEFAULT_MARKETLAKE_ROOT,
+                explicit_source=PathSource.EXPLICIT_MARKETLAKE_ROOT,
+            ),
+            input_path=str(marketlake_root),
+        ),
+        drive_root=drive_root_path,
+    )
+
+
+def _source_for_path(
+    *,
+    value: Path | str,
+    default: str,
+    explicit_source: PathSource,
+) -> PathSource:
+    if Path(value).as_posix() == default:
+        return PathSource.DEFAULT
+    return explicit_source
+
+
+def _resolve_session_path(
+    *,
+    value: Path | str,
+    project_root: Path,
+    source: PathSource,
+    input_path: str | None,
+) -> ResolvedSessionPath:
+    candidate = Path(value).expanduser()
+    base = None if candidate.is_absolute() else project_root.as_posix()
+    resolved = candidate.resolve() if candidate.is_absolute() else (project_root / candidate).resolve()
+    kind = _classify_path(candidate=candidate, resolved=resolved, project_root=project_root)
+    return ResolvedSessionPath(
+        path=_serialize_path(candidate=candidate, resolved=resolved, project_root=project_root, kind=kind),
+        kind=kind,
+        source=source,
+        input_path=input_path,
+        base=base,
+        resolved_path=resolved.as_posix(),
+    )
+
+
+def _classify_path(*, candidate: Path, resolved: Path, project_root: Path) -> PathKind:
+    if _is_relative_to(resolved, project_root):
+        return PathKind.PROJECT_INTERNAL
+    if candidate.is_absolute():
+        return PathKind.EXTERNAL_ABSOLUTE
+    return PathKind.EXTERNAL_OR_PROJECT_RELATIVE
+
+
+def _serialize_path(
+    *,
+    candidate: Path,
+    resolved: Path,
+    project_root: Path,
+    kind: PathKind,
+) -> str:
+    if kind is PathKind.PROJECT_INTERNAL:
+        relative = resolved.relative_to(project_root)
+        serialized = relative.as_posix()
+        return serialized or "."
+    if candidate.is_absolute():
+        return resolved.as_posix()
+    return candidate.as_posix()
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True

--- a/src/session/drive_adapter.py
+++ b/src/session/drive_adapter.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import fnmatch
+import hashlib
+import json
+from pathlib import Path
+import shutil
+from typing import Iterable, Mapping, Sequence
+
+from src.session.contracts import NotebookProjectSession
+from src.session.paths import load_session, resolve_session_paths
+
+DRIVE_SYNC_MANIFEST_SCHEMA_VERSION = 1
+DEFAULT_OPERATION_ID = "latest"
+DEFAULT_INCLUDE_CATEGORIES = ("session_metadata",)
+COPY_CATEGORIES = (
+    "configs",
+    "contracts",
+    "docs",
+    "artifacts",
+    "derived_artifacts",
+    "features",
+    "market_data",
+    "session_metadata",
+)
+SENSITIVE_NAME_FRAGMENTS = (
+    "credential",
+    "credentials",
+    "secret",
+    "secrets",
+    "api_key",
+    "apikey",
+    "access_token",
+    "refresh_token",
+    "private_key",
+)
+EXCLUDED_DIR_NAMES = {
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".ipynb_checkpoints",
+}
+EXCLUDED_FILE_NAMES = {".env"}
+EXCLUDED_PATTERNS = (
+    "*.pyc",
+    "*.pyo",
+    "*.tmp",
+    "*.temp",
+    "*.swp",
+    "*~",
+)
+
+
+@dataclass(frozen=True)
+class SessionCopyItem:
+    operation: str
+    category: str
+    relative_path: str
+    source_path: Path
+    destination_path: Path
+    size_bytes: int
+    sha256: str
+    status: str
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "operation": self.operation,
+            "category": self.category,
+            "relative_path": self.relative_path,
+            "source_path": self.source_path.as_posix(),
+            "destination_path": self.destination_path.as_posix(),
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256,
+            "status": self.status,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class SessionCopyPlan:
+    operation: str
+    dry_run: bool
+    local_root: Path
+    drive_root: Path
+    include_categories: tuple[str, ...]
+    exclude_rules: tuple[str, ...]
+    items: tuple[SessionCopyItem, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "operation": self.operation,
+            "dry_run": self.dry_run,
+            "local_root": self.local_root.as_posix(),
+            "drive_root": self.drive_root.as_posix(),
+            "include_categories": list(self.include_categories),
+            "exclude_rules": list(self.exclude_rules),
+            "items": [item.to_dict() for item in self.items],
+        }
+
+
+@dataclass(frozen=True)
+class SessionCopyResult:
+    plan: SessionCopyPlan
+    copied_count: int
+    skipped_count: int
+    overwritten_count: int
+    manifest_path: Path | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self.plan.to_dict(),
+            "copied_count": self.copied_count,
+            "skipped_count": self.skipped_count,
+            "overwritten_count": self.overwritten_count,
+            "manifest_path": None if self.manifest_path is None else self.manifest_path.as_posix(),
+        }
+
+
+def plan_session_copy(
+    *,
+    operation: str,
+    root: Path | str | NotebookProjectSession,
+    drive_root: Path | str | None = None,
+    include_categories: Iterable[str] | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> SessionCopyPlan:
+    operation = _validate_operation(operation)
+    session = root if isinstance(root, NotebookProjectSession) else load_session(root)
+    paths = resolve_session_paths(session)
+    local_root = Path(paths["project_root"].resolved_path).resolve()
+    effective_drive_root = _resolve_drive_root(drive_root, paths)
+    categories = _normalize_categories(include_categories)
+    items = _build_plan_items(
+        operation=operation,
+        local_root=local_root,
+        drive_root=effective_drive_root,
+        paths=paths,
+        include_categories=categories,
+        force=force,
+        dry_run=dry_run,
+    )
+    return SessionCopyPlan(
+        operation=operation,
+        dry_run=dry_run,
+        local_root=local_root,
+        drive_root=effective_drive_root,
+        include_categories=categories,
+        exclude_rules=_exclude_rules(),
+        items=tuple(items),
+    )
+
+
+def export_session_to_drive(
+    *,
+    root: Path | str | NotebookProjectSession,
+    drive_root: Path | str | None = None,
+    include_categories: Iterable[str] | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+    operation_id: str = DEFAULT_OPERATION_ID,
+    write_manifest: bool | None = None,
+) -> SessionCopyResult:
+    return _execute_session_copy(
+        operation="export",
+        root=root,
+        drive_root=drive_root,
+        include_categories=include_categories,
+        force=force,
+        dry_run=dry_run,
+        operation_id=operation_id,
+        write_manifest=write_manifest,
+    )
+
+
+def import_session_from_drive(
+    *,
+    root: Path | str | NotebookProjectSession,
+    drive_root: Path | str | None = None,
+    include_categories: Iterable[str] | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+    operation_id: str = DEFAULT_OPERATION_ID,
+    write_manifest: bool | None = None,
+) -> SessionCopyResult:
+    return _execute_session_copy(
+        operation="import",
+        root=root,
+        drive_root=drive_root,
+        include_categories=include_categories,
+        force=force,
+        dry_run=dry_run,
+        operation_id=operation_id,
+        write_manifest=write_manifest,
+    )
+
+
+def write_drive_sync_manifest(
+    plan_or_result: SessionCopyPlan | SessionCopyResult,
+    *,
+    operation_id: str = DEFAULT_OPERATION_ID,
+) -> Path:
+    plan = plan_or_result.plan if isinstance(plan_or_result, SessionCopyResult) else plan_or_result
+    manifest_path = _manifest_path(plan.local_root, plan.operation, operation_id)
+    _ensure_under_root(manifest_path, plan.local_root)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(_manifest_data(plan), indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _execute_session_copy(
+    *,
+    operation: str,
+    root: Path | str | NotebookProjectSession,
+    drive_root: Path | str | None,
+    include_categories: Iterable[str] | None,
+    force: bool,
+    dry_run: bool,
+    operation_id: str,
+    write_manifest: bool | None,
+) -> SessionCopyResult:
+    plan = plan_session_copy(
+        operation=operation,
+        root=root,
+        drive_root=drive_root,
+        include_categories=include_categories,
+        force=force,
+        dry_run=dry_run,
+    )
+    copied = 0
+    skipped = 0
+    overwritten = 0
+    if dry_run:
+        for item in plan.items:
+            if item.status.startswith("would_"):
+                continue
+            skipped += 1
+    else:
+        for item in plan.items:
+            if item.status == "skipped":
+                skipped += 1
+                continue
+            item.destination_path.parent.mkdir(parents=True, exist_ok=True)
+            destination_existed = item.destination_path.exists()
+            shutil.copy2(item.source_path, item.destination_path)
+            if destination_existed:
+                overwritten += 1
+            else:
+                copied += 1
+
+    should_write_manifest = (not dry_run) if write_manifest is None else write_manifest
+    manifest_path = write_drive_sync_manifest(plan, operation_id=operation_id) if should_write_manifest else None
+    if dry_run:
+        copied = 0
+        overwritten = 0
+        skipped = len([item for item in plan.items if item.status == "skipped"])
+    return SessionCopyResult(
+        plan=plan,
+        copied_count=copied,
+        skipped_count=skipped,
+        overwritten_count=overwritten,
+        manifest_path=manifest_path,
+    )
+
+
+def _build_plan_items(
+    *,
+    operation: str,
+    local_root: Path,
+    drive_root: Path,
+    paths: Mapping[str, object],
+    include_categories: Sequence[str],
+    force: bool,
+    dry_run: bool,
+) -> list[SessionCopyItem]:
+    items: list[SessionCopyItem] = []
+    for category in include_categories:
+        source_root, destination_root = _category_roots(
+            operation=operation,
+            category=category,
+            local_root=local_root,
+            drive_root=drive_root,
+            paths=paths,
+        )
+        if not source_root.exists():
+            continue
+        for source in _iter_category_files(source_root, category):
+            relative = source.relative_to(source_root).as_posix()
+            destination = (destination_root / relative).resolve()
+            _ensure_under_root(destination, destination_root.resolve())
+            status, reason = _planned_status(destination, force=force, dry_run=dry_run)
+            items.append(
+                SessionCopyItem(
+                    operation=operation,
+                    category=category,
+                    relative_path=relative,
+                    source_path=source.resolve(),
+                    destination_path=destination,
+                    size_bytes=source.stat().st_size,
+                    sha256=_sha256(source),
+                    status=status,
+                    reason=reason,
+                )
+            )
+    return sorted(items, key=lambda item: (item.category, item.relative_path))
+
+
+def _category_roots(
+    *,
+    operation: str,
+    category: str,
+    local_root: Path,
+    drive_root: Path,
+    paths: Mapping[str, object],
+) -> tuple[Path, Path]:
+    local_category_root = _local_category_root(category, local_root, paths)
+    drive_category_root = _drive_category_root(
+        category=category,
+        local_category_root=local_category_root,
+        local_root=local_root,
+        drive_root=drive_root,
+    )
+    if operation == "export":
+        return local_category_root, drive_category_root
+    return drive_category_root, local_category_root
+
+
+def _local_category_root(
+    category: str,
+    local_root: Path,
+    paths: Mapping[str, object],
+) -> Path:
+    if category == "configs":
+        return Path(paths["configs_root"].resolved_path).resolve()  # type: ignore[attr-defined]
+    if category == "contracts":
+        return (local_root / "contracts").resolve()
+    if category == "docs":
+        return (local_root / "docs").resolve()
+    if category == "artifacts":
+        return Path(paths["artifacts_root"].resolved_path).resolve()  # type: ignore[attr-defined]
+    if category == "derived_artifacts":
+        return (Path(paths["artifacts_root"].resolved_path) / "_derived").resolve()  # type: ignore[attr-defined]
+    if category == "features":
+        return Path(paths["features_root"].resolved_path).resolve()  # type: ignore[attr-defined]
+    if category == "market_data":
+        return Path(paths["marketlake_root"].resolved_path).resolve()  # type: ignore[attr-defined]
+    if category == "session_metadata":
+        return (local_root / ".stratlake").resolve()
+    raise ValueError(f"Unsupported copy category: {category}")
+
+
+def _drive_category_root(
+    *,
+    category: str,
+    local_category_root: Path,
+    local_root: Path,
+    drive_root: Path,
+) -> Path:
+    try:
+        relative = local_category_root.relative_to(local_root)
+    except ValueError:
+        return (drive_root / category).resolve()
+    return (drive_root / relative).resolve()
+
+
+def _iter_category_files(root: Path, category: str) -> Iterable[Path]:
+    for path in sorted(root.rglob("*"), key=lambda candidate: candidate.as_posix()):
+        if not path.is_file():
+            continue
+        relative_parts = path.relative_to(root).parts
+        if _is_excluded(path.name, relative_parts):
+            continue
+        if category == "artifacts" and relative_parts and relative_parts[0] == "_derived":
+            continue
+        yield path
+
+
+def _is_excluded(name: str, relative_parts: Sequence[str]) -> bool:
+    lowered_parts = [part.lower() for part in relative_parts]
+    lowered_name = name.lower()
+    if any(part in EXCLUDED_DIR_NAMES for part in lowered_parts):
+        return True
+    if lowered_name in EXCLUDED_FILE_NAMES:
+        return True
+    if any(fragment in lowered_name for fragment in SENSITIVE_NAME_FRAGMENTS):
+        return True
+    return any(fnmatch.fnmatch(lowered_name, pattern) for pattern in EXCLUDED_PATTERNS)
+
+
+def _planned_status(destination: Path, *, force: bool, dry_run: bool) -> tuple[str, str | None]:
+    if destination.exists() and not force:
+        return "skipped", "destination_exists"
+    if dry_run:
+        return ("would_overwrite", None) if destination.exists() else ("would_copy", None)
+    return ("overwritten", None) if destination.exists() else ("copied", None)
+
+
+def _normalize_categories(include_categories: Iterable[str] | None) -> tuple[str, ...]:
+    requested = set(DEFAULT_INCLUDE_CATEGORIES)
+    if include_categories is not None:
+        requested.update(include_categories)
+    unknown = sorted(requested - set(COPY_CATEGORIES))
+    if unknown:
+        joined = ", ".join(unknown)
+        raise ValueError(f"Unknown session copy categories: {joined}")
+    return tuple(category for category in COPY_CATEGORIES if category in requested)
+
+
+def _resolve_drive_root(
+    drive_root: Path | str | None,
+    paths: Mapping[str, object],
+) -> Path:
+    if drive_root is not None:
+        return Path(drive_root).expanduser().resolve()
+    drive = paths.get("drive_root")
+    if drive is None:
+        raise ValueError("A drive root is required. Pass --drive-root or configure drive_root in the session.")
+    return Path(drive.resolved_path).resolve()  # type: ignore[attr-defined]
+
+
+def _manifest_data(plan: SessionCopyPlan) -> dict[str, object]:
+    return {
+        "schema_version": DRIVE_SYNC_MANIFEST_SCHEMA_VERSION,
+        "authoritative": False,
+        **plan.to_dict(),
+    }
+
+
+def _manifest_path(local_root: Path, operation: str, operation_id: str) -> Path:
+    safe_operation_id = _safe_operation_id(operation_id)
+    return (
+        local_root
+        / "artifacts"
+        / "_derived"
+        / "notebook_sessions"
+        / f"{operation}_{safe_operation_id}"
+        / "drive_sync_manifest.json"
+    ).resolve()
+
+
+def _safe_operation_id(operation_id: str) -> str:
+    cleaned = "".join(char if char.isalnum() or char in ("-", "_") else "_" for char in operation_id)
+    return cleaned or DEFAULT_OPERATION_ID
+
+
+def _validate_operation(operation: str) -> str:
+    if operation not in {"export", "import"}:
+        raise ValueError(f"Unsupported session copy operation: {operation}")
+    return operation
+
+
+def _exclude_rules() -> tuple[str, ...]:
+    return (
+        ".env",
+        "*credential*",
+        "*secret*",
+        "*api_key*",
+        "*apikey*",
+        "*access_token*",
+        "*refresh_token*",
+        "*private_key*",
+        "__pycache__/",
+        ".pytest_cache/",
+        ".ruff_cache/",
+        ".mypy_cache/",
+        ".ipynb_checkpoints/",
+        "*.pyc",
+        "*.pyo",
+        "*.tmp",
+        "*.temp",
+        "*.swp",
+        "*~",
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _ensure_under_root(path: Path, root: Path) -> None:
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"Refusing to copy outside root {root.as_posix()}: {path.as_posix()}") from exc

--- a/src/session/drive_adapter.py
+++ b/src/session/drive_adapter.py
@@ -370,9 +370,18 @@ def _drive_category_root(
 
 
 def _iter_category_files(root: Path, category: str) -> Iterable[Path]:
-    for path in sorted(root.rglob("*"), key=lambda candidate: candidate.as_posix()):
-        if not path.is_file():
-            continue
+    def _walk(current: Path) -> Iterable[Path]:
+        for child in sorted(current.iterdir(), key=lambda candidate: candidate.as_posix()):
+            if child.is_symlink():
+                continue
+            if child.is_dir():
+                yield from _walk(child)
+                continue
+            if not child.is_file():
+                continue
+            yield child
+
+    for path in _walk(root):
         relative_parts = path.relative_to(root).parts
         if _is_excluded(path.name, relative_parts):
             continue

--- a/src/session/drive_adapter.py
+++ b/src/session/drive_adapter.py
@@ -84,6 +84,7 @@ class SessionCopyPlan:
     operation: str
     dry_run: bool
     local_root: Path
+    artifacts_root: Path
     drive_root: Path
     include_categories: tuple[str, ...]
     exclude_rules: tuple[str, ...]
@@ -94,6 +95,7 @@ class SessionCopyPlan:
             "operation": self.operation,
             "dry_run": self.dry_run,
             "local_root": self.local_root.as_posix(),
+            "artifacts_root": self.artifacts_root.as_posix(),
             "drive_root": self.drive_root.as_posix(),
             "include_categories": list(self.include_categories),
             "exclude_rules": list(self.exclude_rules),
@@ -132,6 +134,7 @@ def plan_session_copy(
     session = root if isinstance(root, NotebookProjectSession) else load_session(root)
     paths = resolve_session_paths(session)
     local_root = Path(paths["project_root"].resolved_path).resolve()
+    artifacts_root = Path(paths["artifacts_root"].resolved_path).resolve()  # type: ignore[attr-defined]
     effective_drive_root = _resolve_drive_root(drive_root, paths)
     categories = _normalize_categories(include_categories)
     items = _build_plan_items(
@@ -147,6 +150,7 @@ def plan_session_copy(
         operation=operation,
         dry_run=dry_run,
         local_root=local_root,
+        artifacts_root=artifacts_root,
         drive_root=effective_drive_root,
         include_categories=categories,
         exclude_rules=_exclude_rules(),
@@ -204,8 +208,8 @@ def write_drive_sync_manifest(
     operation_id: str = DEFAULT_OPERATION_ID,
 ) -> Path:
     plan = plan_or_result.plan if isinstance(plan_or_result, SessionCopyResult) else plan_or_result
-    manifest_path = _manifest_path(plan.local_root, plan.operation, operation_id)
-    _ensure_under_root(manifest_path, plan.local_root)
+    manifest_path = _manifest_path(plan.artifacts_root, plan.operation, operation_id)
+    _ensure_under_root(manifest_path, plan.artifacts_root)
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text(
         json.dumps(_manifest_data(plan), indent=2, sort_keys=False) + "\n",
@@ -441,11 +445,10 @@ def _manifest_data(plan: SessionCopyPlan) -> dict[str, object]:
     }
 
 
-def _manifest_path(local_root: Path, operation: str, operation_id: str) -> Path:
+def _manifest_path(artifacts_root: Path, operation: str, operation_id: str) -> Path:
     safe_operation_id = _safe_operation_id(operation_id)
     return (
-        local_root
-        / "artifacts"
+        artifacts_root
         / "_derived"
         / "notebook_sessions"
         / f"{operation}_{safe_operation_id}"

--- a/src/session/io.py
+++ b/src/session/io.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+from src.session.contracts import NotebookProjectSession
+
+SESSION_DIR_NAME = ".stratlake"
+SESSION_FILE_NAME = "session.json"
+PATH_RESOLUTION_FILE_NAME = "path_resolution.json"
+
+
+@dataclass(frozen=True)
+class SessionWriteResult:
+    session_path: Path
+    path_resolution_path: Path
+
+
+def write_session_files(
+    session: NotebookProjectSession,
+    *,
+    overwrite: bool = False,
+) -> SessionWriteResult:
+    project_root = Path(session.project_root.resolved_path).resolve()
+    session_dir = (project_root / SESSION_DIR_NAME).resolve()
+    _ensure_under_project_root(session_dir, project_root)
+    session_path = (session_dir / SESSION_FILE_NAME).resolve()
+    resolution_path = (session_dir / PATH_RESOLUTION_FILE_NAME).resolve()
+    _ensure_under_project_root(session_path, project_root)
+    _ensure_under_project_root(resolution_path, project_root)
+
+    existing = [path for path in (session_path, resolution_path) if path.exists()]
+    if existing and not overwrite:
+        joined = ", ".join(path.as_posix() for path in existing)
+        raise FileExistsError(
+            "Refusing to overwrite existing session metadata without overwrite=True: "
+            f"{joined}"
+        )
+
+    project_root.mkdir(parents=True, exist_ok=True)
+    session_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(session_path, session.to_dict())
+    _write_json(resolution_path, session.resolution_report().to_dict())
+    return SessionWriteResult(
+        session_path=session_path,
+        path_resolution_path=resolution_path,
+    )
+
+
+def _write_json(path: Path, data: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(data, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _ensure_under_project_root(path: Path, project_root: Path) -> None:
+    try:
+        path.relative_to(project_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Refusing to write session metadata outside project root: {path.as_posix()}"
+        ) from exc

--- a/src/session/paths.py
+++ b/src/session/paths.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Mapping
+
+from src.session.contracts import (
+    DEFAULT_ARTIFACTS_ROOT,
+    DEFAULT_CONFIGS_ROOT,
+    DEFAULT_FEATURES_ROOT,
+    DEFAULT_MARKETLAKE_ROOT,
+    SESSION_SCHEMA_VERSION,
+    NotebookProjectSession,
+    PathKind,
+    PathSource,
+    ResolvedSessionPath,
+)
+from src.session.io import PATH_RESOLUTION_FILE_NAME, SESSION_DIR_NAME, SESSION_FILE_NAME
+
+SESSION_PATH_KEYS = (
+    "notebook_cwd",
+    "project_root",
+    "configs_root",
+    "artifacts_root",
+    "features_root",
+    "marketlake_root",
+    "drive_root",
+)
+REQUIRED_SESSION_FIELDS = (
+    "schema_version",
+    "project_name",
+    "notebook_cwd",
+    "project_root",
+    "configs_root",
+    "artifacts_root",
+    "features_root",
+    "marketlake_root",
+)
+ENVIRONMENT_FALLBACKS = {
+    "artifacts_root": "ARTIFACTS_ROOT",
+    "features_root": "FEATURES_ROOT",
+    "marketlake_root": "MARKETLAKE_ROOT",
+}
+DEFAULT_PATHS = {
+    "configs_root": DEFAULT_CONFIGS_ROOT,
+    "artifacts_root": DEFAULT_ARTIFACTS_ROOT,
+    "features_root": DEFAULT_FEATURES_ROOT,
+    "marketlake_root": DEFAULT_MARKETLAKE_ROOT,
+}
+
+
+def find_session_root(start: Path | str | None = None) -> Path:
+    candidate = Path.cwd() if start is None else Path(start).expanduser()
+    candidate = candidate.resolve()
+    if candidate.is_file():
+        candidate = candidate.parent
+
+    for current in (candidate, *candidate.parents):
+        if (current / SESSION_DIR_NAME / SESSION_FILE_NAME).is_file():
+            return current
+    raise FileNotFoundError(
+        f"No StratLake session root found from {candidate.as_posix()}. "
+        f"Expected {SESSION_DIR_NAME}/{SESSION_FILE_NAME} in this directory or a parent."
+    )
+
+
+def load_session(root: Path | str) -> NotebookProjectSession:
+    session_root = find_session_root(root)
+    session_path = session_root / SESSION_DIR_NAME / SESSION_FILE_NAME
+    try:
+        raw = json.loads(session_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid StratLake session JSON: {session_path.as_posix()}") from exc
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Invalid StratLake session JSON object: {session_path.as_posix()}")
+    _validate_session_payload(raw, session_path)
+    return _session_from_payload(raw, session_root)
+
+
+def resolve_session_paths(
+    session_or_root: NotebookProjectSession | Path | str | Mapping[str, object],
+    overrides: Mapping[str, Path | str | None] | None = None,
+) -> dict[str, ResolvedSessionPath]:
+    session, session_root = _coerce_session(session_or_root)
+    override_values = dict(overrides or {})
+    unknown = sorted(set(override_values) - set(SESSION_PATH_KEYS))
+    if unknown:
+        joined = ", ".join(unknown)
+        raise ValueError(f"Unknown session path override(s): {joined}")
+
+    resolved: dict[str, ResolvedSessionPath] = {}
+    resolved["project_root"] = _resolve_path_value(
+        value=override_values.get("project_root", "."),
+        project_root=session_root,
+        source=PathSource.EXPLICIT_OVERRIDE
+        if "project_root" in override_values
+        else PathSource.SESSION_METADATA,
+        input_path=_input_value(override_values, "project_root", session.project_root.path),
+    )
+
+    for key in ("notebook_cwd", "configs_root", "artifacts_root", "features_root", "marketlake_root"):
+        value, source, input_path = _select_path_value(
+            key=key,
+            session=session,
+            overrides=override_values,
+        )
+        resolved[key] = _resolve_path_value(
+            value=value,
+            project_root=session_root,
+            source=source,
+            input_path=input_path,
+        )
+
+    if "drive_root" in override_values:
+        drive_override = override_values["drive_root"]
+        if drive_override is not None:
+            resolved["drive_root"] = _resolve_path_value(
+                value=drive_override,
+                project_root=session_root,
+                source=PathSource.EXPLICIT_OVERRIDE,
+                input_path=str(drive_override),
+            )
+    elif session.drive_root is not None:
+        resolved["drive_root"] = _resolve_path_value(
+            value=session.drive_root.path,
+            project_root=session_root,
+            source=PathSource.SESSION_METADATA,
+            input_path=session.drive_root.path,
+        )
+
+    return resolved
+
+
+def write_path_resolution_report(
+    session_or_root: NotebookProjectSession | Path | str | Mapping[str, object],
+    *,
+    overrides: Mapping[str, Path | str | None] | None = None,
+    overwrite: bool = True,
+) -> Path:
+    session, session_root = _coerce_session(session_or_root)
+    path_resolution_path = (
+        session_root / SESSION_DIR_NAME / PATH_RESOLUTION_FILE_NAME
+    ).resolve()
+    _ensure_under_project_root(path_resolution_path, session_root)
+    if path_resolution_path.exists() and not overwrite:
+        raise FileExistsError(
+            "Refusing to overwrite existing path resolution report without overwrite=True: "
+            f"{path_resolution_path.as_posix()}"
+        )
+
+    paths = resolve_session_paths(session, overrides=overrides)
+    data = {
+        "schema_version": session.schema_version,
+        "project_name": session.project_name,
+        "paths": {key: value.to_resolution_dict() for key, value in paths.items()},
+    }
+    path_resolution_path.parent.mkdir(parents=True, exist_ok=True)
+    path_resolution_path.write_text(
+        json.dumps(data, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    return path_resolution_path
+
+
+def _validate_session_payload(payload: Mapping[str, object], session_path: Path) -> None:
+    missing = [key for key in REQUIRED_SESSION_FIELDS if key not in payload]
+    if missing:
+        joined = ", ".join(missing)
+        raise ValueError(
+            f"StratLake session file is missing required field(s) {joined}: "
+            f"{session_path.as_posix()}"
+        )
+    if payload["schema_version"] != SESSION_SCHEMA_VERSION:
+        raise ValueError(
+            "Unsupported StratLake session schema version "
+            f"{payload['schema_version']!r}; expected {SESSION_SCHEMA_VERSION}."
+        )
+    if not isinstance(payload["project_name"], str) or not payload["project_name"]:
+        raise ValueError(f"StratLake session project_name must be a non-empty string: {session_path.as_posix()}")
+    for key in REQUIRED_SESSION_FIELDS:
+        if key in ("schema_version", "project_name"):
+            continue
+        _validate_path_payload(key, payload[key], session_path)
+    if "drive_root" in payload:
+        _validate_path_payload("drive_root", payload["drive_root"], session_path)
+
+
+def _validate_path_payload(key: str, value: object, session_path: Path) -> None:
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"StratLake session field {key} must be a path object: {session_path.as_posix()}"
+        )
+    for field in ("path", "kind", "source"):
+        if field not in value:
+            raise ValueError(
+                f"StratLake session field {key} is missing {field}: {session_path.as_posix()}"
+            )
+        if not isinstance(value[field], str):
+            raise ValueError(
+                f"StratLake session field {key}.{field} must be a string: {session_path.as_posix()}"
+            )
+    if not value["path"]:
+        raise ValueError(
+            f"StratLake session field {key}.path must be non-empty: {session_path.as_posix()}"
+        )
+    _coerce_path_kind(value["kind"])
+    _coerce_path_source(value["source"])
+
+
+def _session_from_payload(payload: Mapping[str, object], session_root: Path) -> NotebookProjectSession:
+    drive_persistence = payload.get("drive_persistence", {})
+    drive_persistence_enabled = False
+    if isinstance(drive_persistence, dict):
+        drive_persistence_enabled = bool(drive_persistence.get("enabled", False))
+
+    return NotebookProjectSession(
+        schema_version=SESSION_SCHEMA_VERSION,
+        project_name=str(payload["project_name"]),
+        notebook_cwd=_loaded_path("notebook_cwd", payload["notebook_cwd"], session_root),
+        project_root=_loaded_path("project_root", payload["project_root"], session_root),
+        configs_root=_loaded_path("configs_root", payload["configs_root"], session_root),
+        artifacts_root=_loaded_path("artifacts_root", payload["artifacts_root"], session_root),
+        features_root=_loaded_path("features_root", payload["features_root"], session_root),
+        marketlake_root=_loaded_path("marketlake_root", payload["marketlake_root"], session_root),
+        drive_root=_loaded_path("drive_root", payload["drive_root"], session_root)
+        if "drive_root" in payload
+        else None,
+        drive_persistence_enabled=drive_persistence_enabled,
+    )
+
+
+def _loaded_path(
+    key: str,
+    value: object,
+    session_root: Path,
+) -> ResolvedSessionPath:
+    if not isinstance(value, dict):
+        raise ValueError(f"Invalid loaded path for {key}")
+    path_text = str(value["path"])
+    if not path_text:
+        return ResolvedSessionPath(
+            path="",
+            kind=_coerce_path_kind(str(value["kind"])),
+            source=_coerce_path_source(str(value["source"])),
+            resolved_path="",
+            input_path="",
+            base=None,
+        )
+    resolved = _resolve_path_value(
+        value=path_text,
+        project_root=session_root,
+        source=_coerce_path_source(str(value["source"])),
+        input_path=path_text,
+    )
+    expected_kind = _coerce_path_kind(str(value["kind"]))
+    if resolved.kind is not expected_kind:
+        return ResolvedSessionPath(
+            path=resolved.path,
+            kind=expected_kind,
+            source=resolved.source,
+            resolved_path=resolved.resolved_path,
+            input_path=resolved.input_path,
+            base=resolved.base,
+        )
+    return resolved
+
+
+def _coerce_session(
+    session_or_root: NotebookProjectSession | Path | str | Mapping[str, object],
+) -> tuple[NotebookProjectSession, Path]:
+    if isinstance(session_or_root, NotebookProjectSession):
+        session_root = Path(session_or_root.project_root.resolved_path).resolve()
+        return session_or_root, session_root
+    if isinstance(session_or_root, Mapping):
+        project_root_value = session_or_root.get("project_root")
+        if not isinstance(project_root_value, Mapping):
+            raise ValueError("Session mapping must include project_root metadata")
+        root_value = project_root_value.get("resolved_path")
+        if not isinstance(root_value, str):
+            raise ValueError("Session mapping must include project_root.resolved_path")
+        root = Path(root_value).resolve()
+        return _session_from_payload(session_or_root, root), root
+    session = load_session(session_or_root)
+    return session, Path(session.project_root.resolved_path).resolve()
+
+
+def _select_path_value(
+    *,
+    key: str,
+    session: NotebookProjectSession,
+    overrides: Mapping[str, Path | str | None],
+) -> tuple[Path | str, PathSource, str | None]:
+    if key in overrides and overrides[key] is not None:
+        return overrides[key], PathSource.EXPLICIT_OVERRIDE, str(overrides[key])
+
+    session_value = getattr(session, key)
+    if isinstance(session_value, ResolvedSessionPath) and session_value.path:
+        return session_value.path, PathSource.SESSION_METADATA, session_value.path
+
+    env_name = ENVIRONMENT_FALLBACKS.get(key)
+    if env_name and os.environ.get(env_name):
+        value = os.environ[env_name]
+        return value, PathSource.ENVIRONMENT_VARIABLE, f"{env_name}={value}"
+
+    if key in DEFAULT_PATHS:
+        value = DEFAULT_PATHS[key]
+        return value, PathSource.DEFAULT, value
+
+    raise ValueError(f"No value available for required session path: {key}")
+
+
+def _input_value(
+    overrides: Mapping[str, Path | str | None],
+    key: str,
+    fallback: str,
+) -> str | None:
+    if key in overrides:
+        return None if overrides[key] is None else str(overrides[key])
+    return fallback
+
+
+def _resolve_path_value(
+    *,
+    value: Path | str,
+    project_root: Path,
+    source: PathSource,
+    input_path: str | None,
+) -> ResolvedSessionPath:
+    candidate = Path(value).expanduser()
+    base = None if candidate.is_absolute() else project_root.as_posix()
+    resolved = candidate.resolve() if candidate.is_absolute() else (project_root / candidate).resolve()
+    kind = _classify_path(candidate=candidate, resolved=resolved, project_root=project_root)
+    return ResolvedSessionPath(
+        path=_serialize_path(candidate=candidate, resolved=resolved, project_root=project_root, kind=kind),
+        kind=kind,
+        source=source,
+        input_path=input_path,
+        base=base,
+        resolved_path=resolved.as_posix(),
+    )
+
+
+def _classify_path(*, candidate: Path, resolved: Path, project_root: Path) -> PathKind:
+    if _is_relative_to(resolved, project_root):
+        return PathKind.PROJECT_INTERNAL
+    if candidate.is_absolute():
+        return PathKind.EXTERNAL_ABSOLUTE
+    return PathKind.EXTERNAL_OR_PROJECT_RELATIVE
+
+
+def _serialize_path(
+    *,
+    candidate: Path,
+    resolved: Path,
+    project_root: Path,
+    kind: PathKind,
+) -> str:
+    if kind is PathKind.PROJECT_INTERNAL:
+        relative = resolved.relative_to(project_root)
+        serialized = relative.as_posix()
+        return serialized or "."
+    if candidate.is_absolute():
+        return resolved.as_posix()
+    return candidate.as_posix()
+
+
+def _coerce_path_kind(value: str) -> PathKind:
+    try:
+        return PathKind(value)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported StratLake session path kind: {value}") from exc
+
+
+def _coerce_path_source(value: str) -> PathSource:
+    try:
+        return PathSource(value)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported StratLake session path source: {value}") from exc
+
+
+def _ensure_under_project_root(path: Path, project_root: Path) -> None:
+    try:
+        path.relative_to(project_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Refusing to write path resolution report outside project root: {path.as_posix()}"
+        ) from exc
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True

--- a/src/session/paths.py
+++ b/src/session/paths.py
@@ -278,9 +278,11 @@ def _coerce_session(
         if not isinstance(project_root_value, Mapping):
             raise ValueError("Session mapping must include project_root metadata")
         root_value = project_root_value.get("resolved_path")
-        if not isinstance(root_value, str):
-            raise ValueError("Session mapping must include project_root.resolved_path")
-        root = Path(root_value).resolve()
+        root = (
+            Path(root_value).resolve()
+            if isinstance(root_value, str) and root_value
+            else find_session_root()
+        )
         return _session_from_payload(session_or_root, root), root
     session = load_session(session_or_root)
     return session, Path(session.project_root.resolved_path).resolve()

--- a/src/session/serialization.py
+++ b/src/session/serialization.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from src.session.contracts import NotebookProjectSession, PathResolutionReport
+
+
+def session_to_dict(session: NotebookProjectSession) -> dict[str, object]:
+    return session.to_dict()
+
+
+def path_resolution_to_dict(report: PathResolutionReport) -> dict[str, object]:
+    return report.to_dict()

--- a/tests/test_drive_persistence_adapter.py
+++ b/tests/test_drive_persistence_adapter.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.session import create_notebook_project_session, write_session_files
+from src.session.drive_adapter import (
+    export_session_to_drive,
+    import_session_from_drive,
+    plan_session_copy,
+)
+
+
+def _make_session_roots(tmp_path: Path) -> tuple[Path, Path]:
+    local_root = tmp_path / "local-stratlake"
+    drive_root = tmp_path / "mounted-drive" / "stratlake-demo"
+    session = create_notebook_project_session(
+        project_root=local_root,
+        project_name="demo",
+        drive_root=drive_root,
+        drive_persistence_enabled=True,
+    )
+    write_session_files(session)
+    return local_root, drive_root
+
+
+def _write(path: Path, text: str = "content\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_export_dry_run_creates_plan_and_writes_no_copied_files(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "alpha.yml", "alpha: 1\n")
+
+    result = export_session_to_drive(
+        root=local_root,
+        include_categories=("configs",),
+        dry_run=True,
+    )
+
+    planned = [item for item in result.plan.items if item.category == "configs"]
+    assert planned[0].status == "would_copy"
+    assert result.copied_count == 0
+    assert result.manifest_path is None
+    assert not (drive_root / "configs" / "alpha.yml").exists()
+
+
+def test_export_copies_selected_configs_only_when_included(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "alpha.yml")
+    _write(local_root / "docs" / "guide.md")
+
+    export_session_to_drive(root=local_root, include_categories=("configs",))
+
+    assert (drive_root / "configs" / "alpha.yml").is_file()
+    assert not (drive_root / "docs" / "guide.md").exists()
+
+
+def test_export_copies_selected_artifacts_only_when_included(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "artifacts" / "run" / "summary.json", "{}\n")
+    _write(local_root / "configs" / "alpha.yml")
+
+    export_session_to_drive(root=local_root, include_categories=("artifacts",))
+
+    assert (drive_root / "artifacts" / "run" / "summary.json").is_file()
+    assert not (drive_root / "configs" / "alpha.yml").exists()
+
+
+def test_export_feature_and_market_data_require_explicit_categories(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "data" / "curated" / "features.parquet", "feature-data\n")
+
+    export_session_to_drive(root=local_root, include_categories=("configs",))
+    assert not (drive_root / "data" / "curated" / "features.parquet").exists()
+
+    export_session_to_drive(root=local_root, include_categories=("features",), force=True)
+    assert (drive_root / "data" / "curated" / "features.parquet").is_file()
+
+    market_target = drive_root / "data" / "curated" / "market.parquet"
+    _write(local_root / "data" / "curated" / "market.parquet", "market-data\n")
+    market_target.unlink(missing_ok=True)
+    export_session_to_drive(root=local_root, include_categories=("market_data",), force=True)
+    assert market_target.is_file()
+
+
+def test_safe_default_excludes_sensitive_and_cache_files(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "alpha.yml")
+    _write(local_root / "configs" / ".env", "TOKEN=secret\n")
+    _write(local_root / "configs" / "api_key.txt", "secret\n")
+    _write(local_root / "configs" / "credentials.json", "{}\n")
+    _write(local_root / "configs" / ".ipynb_checkpoints" / "alpha.yml")
+    _write(local_root / "configs" / "__pycache__" / "cached.pyc", "bytecode\n")
+    _write(local_root / "configs" / "scratch.tmp", "tmp\n")
+
+    export_session_to_drive(root=local_root, include_categories=("configs",))
+
+    assert (drive_root / "configs" / "alpha.yml").is_file()
+    assert not (drive_root / "configs" / ".env").exists()
+    assert not (drive_root / "configs" / "api_key.txt").exists()
+    assert not (drive_root / "configs" / "credentials.json").exists()
+    assert not (drive_root / "configs" / ".ipynb_checkpoints").exists()
+    assert not (drive_root / "configs" / "__pycache__").exists()
+    assert not (drive_root / "configs" / "scratch.tmp").exists()
+
+
+def test_manifest_includes_deterministic_order_and_file_metadata(tmp_path: Path) -> None:
+    local_root, _drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "b.yml", "b\n")
+    _write(local_root / "configs" / "a.yml", "a\n")
+
+    result = export_session_to_drive(
+        root=local_root,
+        include_categories=("configs",),
+        operation_id="deterministic-test",
+    )
+
+    assert result.manifest_path is not None
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    item_paths = [item["relative_path"] for item in manifest["items"] if item["category"] == "configs"]
+    assert item_paths == ["a.yml", "b.yml"]
+    item = next(item for item in manifest["items"] if item["relative_path"] == "a.yml")
+    assert item["source_path"]
+    assert item["destination_path"]
+    assert item["category"] == "configs"
+    assert item["size_bytes"] == len((local_root / "configs" / "a.yml").read_bytes())
+    assert len(item["sha256"]) == 64
+    assert item["status"] == "copied"
+    assert manifest["authoritative"] is False
+
+
+def test_import_does_not_overwrite_by_default_and_force_overwrites(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "alpha.yml", "local\n")
+    _write(drive_root / "configs" / "alpha.yml", "drive\n")
+
+    result = import_session_from_drive(root=local_root, include_categories=("configs",))
+    assert result.skipped_count >= 1
+    assert (local_root / "configs" / "alpha.yml").read_text(encoding="utf-8") == "local\n"
+
+    result = import_session_from_drive(root=local_root, include_categories=("configs",), force=True)
+    assert result.overwritten_count >= 1
+    assert (local_root / "configs" / "alpha.yml").read_text(encoding="utf-8") == "drive\n"
+
+
+def test_adapter_uses_generic_mounted_filesystem_paths(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    generic_mount = tmp_path / "generic-mounted-filesystem"
+    _write(local_root / "configs" / "alpha.yml")
+
+    export_session_to_drive(
+        root=local_root,
+        drive_root=generic_mount,
+        include_categories=("configs",),
+    )
+
+    assert (generic_mount / "configs" / "alpha.yml").is_file()
+    assert drive_root != generic_mount
+
+
+def test_plan_session_copy_is_deterministic(tmp_path: Path) -> None:
+    local_root, _drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "b.yml")
+    _write(local_root / "configs" / "a.yml")
+
+    first = plan_session_copy(
+        operation="export",
+        root=local_root,
+        include_categories=("configs",),
+        dry_run=True,
+    )
+    second = plan_session_copy(
+        operation="export",
+        root=local_root,
+        include_categories=("configs",),
+        dry_run=True,
+    )
+
+    assert [item.to_dict() for item in first.items] == [item.to_dict() for item in second.items]

--- a/tests/test_drive_persistence_adapter.py
+++ b/tests/test_drive_persistence_adapter.py
@@ -131,6 +131,48 @@ def test_manifest_includes_deterministic_order_and_file_metadata(tmp_path: Path)
     assert manifest["authoritative"] is False
 
 
+def test_drive_manifest_uses_resolved_artifacts_root(tmp_path: Path) -> None:
+    project_root = tmp_path / "workspace"
+    custom_artifacts = tmp_path / "custom-artifacts"
+    drive_root = tmp_path / "mounted-drive"
+    session = create_notebook_project_session(
+        project_root=project_root,
+        artifacts_root=custom_artifacts,
+        drive_root=drive_root,
+    )
+    write_session_files(session)
+    _write(project_root / "configs" / "demo.yml", "demo: true\n")
+
+    result = export_session_to_drive(
+        root=project_root,
+        include_categories=("configs",),
+        operation_id="custom-artifacts",
+    )
+
+    expected_manifest = (
+        custom_artifacts
+        / "_derived"
+        / "notebook_sessions"
+        / "export_custom-artifacts"
+        / "drive_sync_manifest.json"
+    ).resolve()
+    unexpected_project_manifest = (
+        project_root
+        / "artifacts"
+        / "_derived"
+        / "notebook_sessions"
+        / "export_custom-artifacts"
+        / "drive_sync_manifest.json"
+    )
+
+    assert result.manifest_path == expected_manifest
+    assert expected_manifest.is_file()
+    assert not unexpected_project_manifest.exists()
+    manifest = json.loads(expected_manifest.read_text(encoding="utf-8"))
+    assert manifest["artifacts_root"] == custom_artifacts.resolve().as_posix()
+    assert manifest["authoritative"] is False
+
+
 def test_import_does_not_overwrite_by_default_and_force_overwrites(tmp_path: Path) -> None:
     local_root, drive_root = _make_session_roots(tmp_path)
     _write(local_root / "configs" / "alpha.yml", "local\n")

--- a/tests/test_init_notebook_workspace.py
+++ b/tests/test_init_notebook_workspace.py
@@ -20,6 +20,7 @@ def test_initialize_notebook_workspace_creates_expected_layout(tmp_path: Path) -
         assert (workspace_root / directory).is_dir()
 
     assert (workspace_root / "configs" / "features.yml").is_file()
+    assert (workspace_root / "configs" / "session.yml").is_file()
     assert (workspace_root / "configs" / "profiles" / "notebook.yml").is_file()
     assert (workspace_root / "docs" / "notebook_integration.md").is_file()
     assert (workspace_root / "docs" / "examples" / "notebook_execution_api_examples.py").is_file()
@@ -107,6 +108,7 @@ def test_package_resources_are_discoverable() -> None:
     resource_root = _resolve_resource_root()
 
     assert resource_root.joinpath("configs").joinpath("features.yml").is_file()
+    assert resource_root.joinpath("configs").joinpath("session.yml").is_file()
     assert resource_root.joinpath("configs").joinpath("profiles").joinpath("notebook.yml").is_file()
     assert resource_root.joinpath("docs").joinpath("notebook_integration.md").is_file()
     assert (

--- a/tests/test_init_notebook_workspace.py
+++ b/tests/test_init_notebook_workspace.py
@@ -23,6 +23,7 @@ def test_initialize_notebook_workspace_creates_expected_layout(tmp_path: Path) -
     assert (workspace_root / "configs" / "session.yml").is_file()
     assert (workspace_root / "configs" / "profiles" / "notebook.yml").is_file()
     assert (workspace_root / "docs" / "notebook_integration.md").is_file()
+    assert (workspace_root / "docs" / "colab_project_sessions.md").is_file()
     assert (workspace_root / "docs" / "examples" / "notebook_execution_api_examples.py").is_file()
 
     assert summary["workspace_preexisting"] is False
@@ -111,6 +112,7 @@ def test_package_resources_are_discoverable() -> None:
     assert resource_root.joinpath("configs").joinpath("session.yml").is_file()
     assert resource_root.joinpath("configs").joinpath("profiles").joinpath("notebook.yml").is_file()
     assert resource_root.joinpath("docs").joinpath("notebook_integration.md").is_file()
+    assert resource_root.joinpath("docs").joinpath("colab_project_sessions.md").is_file()
     assert (
         resource_root.joinpath("docs").joinpath("examples").joinpath("notebook_execution_api_examples.py").is_file()
     )

--- a/tests/test_init_session_cli.py
+++ b/tests/test_init_session_cli.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from src.cli.init_session import main, run_cli
+from src.cli.init_notebook_workspace import _resolve_resource_root
+
+
+def test_init_session_first_run_creates_workspace_and_session_files(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+
+    summary = run_cli(
+        [
+            "--root",
+            str(project_root),
+            "--project-name",
+            "demo",
+            "--marketlake-root",
+            "./fintech/data/curated",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert (project_root / "notebooks").is_dir()
+    assert (project_root / "configs" / "session.yml").is_file()
+    assert (project_root / "docs" / "notebook_integration.md").is_file()
+    assert (project_root / ".stratlake" / "session.json").is_file()
+    assert (project_root / ".stratlake" / "path_resolution.json").is_file()
+    assert summary["session_path"] == (project_root / ".stratlake" / "session.json").as_posix()
+    assert "Initialized StratLake notebook session at:" in captured.out
+    assert "Template status:" in captured.out
+    assert "Next: open notebooks from this project root" in captured.out
+
+
+def test_init_session_writes_required_session_json_fields(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+
+    run_cli(["--root", str(project_root), "--project-name", "demo"])
+
+    session_json = json.loads(
+        (project_root / ".stratlake" / "session.json").read_text(encoding="utf-8")
+    )
+    resolution_json = json.loads(
+        (project_root / ".stratlake" / "path_resolution.json").read_text(encoding="utf-8")
+    )
+    assert session_json["schema_version"] == 1
+    assert session_json["project_name"] == "demo"
+    assert session_json["project_root"]["path"] == "."
+    assert session_json["configs_root"]["path"] == "configs"
+    assert session_json["artifacts_root"]["path"] == "artifacts"
+    assert session_json["features_root"]["path"] == "data/curated"
+    assert session_json["drive_persistence"] == {
+        "enabled": False,
+        "mode": "metadata_only",
+    }
+    assert resolution_json["paths"]["project_root"]["source"] == "explicit_root"
+    assert resolution_json["paths"]["configs_root"]["base"] == project_root.resolve().as_posix()
+
+
+def test_repeated_run_without_force_preserves_user_files_and_fails_clearly(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    run_cli(["--root", str(project_root), "--project-name", "demo"])
+    user_config = project_root / "configs" / "session.yml"
+    user_config.write_text("user-owned: true\n", encoding="utf-8")
+
+    exit_code = main(["--root", str(project_root), "--project-name", "demo"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "Session metadata already exists" in captured.err
+    assert user_config.read_text(encoding="utf-8") == "user-owned: true\n"
+
+
+def test_force_refreshes_known_templates_and_session_metadata_only(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    run_cli(["--root", str(project_root), "--project-name", "demo"])
+    known_template = project_root / "configs" / "session.yml"
+    unrelated_config = project_root / "configs" / "custom_user_config.yml"
+    artifact = project_root / "artifacts" / "canonical.txt"
+    known_template.write_text("user-edited-template: true\n", encoding="utf-8")
+    unrelated_config.write_text("do-not-touch: true\n", encoding="utf-8")
+    artifact.write_text("canonical artifact\n", encoding="utf-8")
+
+    summary = run_cli(
+        [
+            "--root",
+            str(project_root),
+            "--project-name",
+            "demo-force",
+            "--force",
+        ]
+    )
+
+    assert "configs/session.yml" in summary["bootstrap"]["overwritten"]
+    assert "user-edited-template" not in known_template.read_text(encoding="utf-8")
+    assert unrelated_config.read_text(encoding="utf-8") == "do-not-touch: true\n"
+    assert artifact.read_text(encoding="utf-8") == "canonical artifact\n"
+    session_json = json.loads(
+        (project_root / ".stratlake" / "session.json").read_text(encoding="utf-8")
+    )
+    assert session_json["project_name"] == "demo-force"
+
+
+def test_external_marketlake_root_is_classified_as_external(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    marketlake_root = tmp_path / "external-marketlake" / "data" / "curated"
+
+    run_cli(
+        [
+            "--root",
+            str(project_root),
+            "--marketlake-root",
+            str(marketlake_root),
+        ]
+    )
+
+    session_json = json.loads(
+        (project_root / ".stratlake" / "session.json").read_text(encoding="utf-8")
+    )
+    assert session_json["marketlake_root"]["path"] == marketlake_root.resolve().as_posix()
+    assert session_json["marketlake_root"]["kind"] == "external_absolute"
+    assert session_json["marketlake_root"]["source"] == "explicit_marketlake_root"
+
+
+def test_drive_persistence_records_metadata_without_drive_sync(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    drive_root = tmp_path / "drive" / "MyDrive" / "stratlake-demo"
+
+    run_cli(
+        [
+            "--root",
+            str(project_root),
+            "--drive-root",
+            str(drive_root),
+            "--enable-drive-persistence",
+        ]
+    )
+
+    session_json = json.loads(
+        (project_root / ".stratlake" / "session.json").read_text(encoding="utf-8")
+    )
+    assert session_json["drive_root"]["path"] == drive_root.resolve().as_posix()
+    assert session_json["drive_root"]["kind"] == "external_absolute"
+    assert session_json["drive_persistence"] == {
+        "enabled": True,
+        "mode": "metadata_only",
+    }
+    assert not drive_root.exists()
+
+
+def test_enable_drive_persistence_requires_drive_root(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_cli(["--root", str(project_root), "--enable-drive-persistence"])
+
+    assert exc_info.value.code == 2
+    assert not project_root.exists()
+
+
+def test_init_session_uses_explicit_root_from_any_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    notebook_cwd = tmp_path / "notebook-cwd"
+    notebook_cwd.mkdir()
+    monkeypatch.chdir(notebook_cwd)
+
+    run_cli(["--root", str(project_root), "--project-name", "demo"])
+
+    assert (project_root / ".stratlake" / "session.json").is_file()
+    assert not (notebook_cwd / ".stratlake").exists()
+
+
+def test_init_session_does_not_mutate_env_files_or_process_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    env_path = project_root / ".env"
+    project_root.mkdir()
+    env_path.write_text("SENTINEL=1\n", encoding="utf-8")
+    before_environ = dict(os.environ)
+    monkeypatch.setenv("STRATLAKE_TEST_SENTINEL", "keep")
+
+    run_cli(["--root", str(project_root), "--project-name", "demo"])
+
+    assert env_path.read_text(encoding="utf-8") == "SENTINEL=1\n"
+    assert os.environ["STRATLAKE_TEST_SENTINEL"] == "keep"
+    after_environ = dict(os.environ)
+    after_environ.pop("STRATLAKE_TEST_SENTINEL", None)
+    assert after_environ == before_environ
+
+
+def test_init_session_does_not_mutate_package_resource_templates(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    resource = _resolve_resource_root().joinpath("configs").joinpath("session.yml")
+    before = resource.read_text(encoding="utf-8")
+
+    run_cli(["--root", str(project_root), "--project-name", "demo", "--force"])
+
+    assert resource.read_text(encoding="utf-8") == before
+
+
+def test_unsafe_session_metadata_write_outside_root_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    monkeypatch.setattr("src.cli.init_session.SESSION_DIR_NAME", "../outside")
+
+    exit_code = main(["--root", str(project_root)])
+
+    assert exit_code == 2
+    assert not project_root.exists()

--- a/tests/test_m42_release_validation.py
+++ b/tests/test_m42_release_validation.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from src.cli.init_session import run_cli as run_init_session
+from src.cli.session_export import run_cli as run_export
+from src.cli.session_import import run_cli as run_import
+from src.session import load_session, resolve_session_paths
+
+
+def test_m42_full_notebook_session_lifecycle_is_deterministic_and_ci_safe(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "stratlake"
+    drive_root = tmp_path / "mounted-drive" / "stratlake-demo"
+    marketlake_root = tmp_path / "external-marketlake" / "data" / "curated"
+    before_environ = dict(os.environ)
+
+    init_summary = run_init_session(
+        [
+            "--root",
+            str(project_root),
+            "--project-name",
+            "stratlake-demo",
+            "--marketlake-root",
+            str(marketlake_root),
+            "--drive-root",
+            str(drive_root),
+            "--enable-drive-persistence",
+        ]
+    )
+
+    assert (project_root / "configs" / "session.yml").is_file()
+    assert (project_root / "docs" / "colab_project_sessions.md").is_file()
+    assert Path(init_summary["session_path"]).is_file()
+    assert Path(init_summary["path_resolution_path"]).is_file()
+
+    session_json = json.loads((project_root / ".stratlake" / "session.json").read_text())
+    path_resolution = json.loads(
+        (project_root / ".stratlake" / "path_resolution.json").read_text()
+    )
+    assert session_json["schema_version"] == 1
+    assert session_json["project_root"]["path"] == "."
+    assert session_json["configs_root"]["path"] == "configs"
+    assert session_json["artifacts_root"]["path"] == "artifacts"
+    assert session_json["features_root"]["path"] == "data/curated"
+    assert session_json["marketlake_root"]["kind"] == "external_absolute"
+    assert session_json["drive_root"]["kind"] == "external_absolute"
+    assert path_resolution["paths"]["marketlake_root"]["source"] == "explicit_marketlake_root"
+
+    session = load_session(project_root)
+    paths = resolve_session_paths(session)
+    assert Path(paths["configs_root"].resolved_path) == project_root / "configs"
+    assert Path(paths["marketlake_root"].resolved_path) == marketlake_root
+    assert Path(paths["drive_root"].resolved_path) == drive_root
+
+    _write(project_root / "configs" / "alpha.yml", "alpha: 1\n")
+    _write(project_root / "configs" / ".env", "TOKEN=secret\n")
+    _write(project_root / "configs" / "api_key.txt", "secret\n")
+    _write(project_root / "artifacts" / "run" / "summary.json", "{}\n")
+    _write(project_root / "data" / "curated" / "features_daily" / "part-000.csv", "feature\n")
+    _write(marketlake_root / "raw_market" / "part-000.csv", "market\n")
+
+    dry_run = run_export(
+        [
+            "--root",
+            str(project_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-configs",
+            "--include-artifacts",
+            "--dry-run",
+        ]
+    )
+    assert dry_run["dry_run"] is True
+    assert dry_run["copied_count"] == 0
+    assert dry_run["manifest_path"] is None
+    assert not (drive_root / "configs" / "alpha.yml").exists()
+
+    export_without_data = run_export(
+        [
+            "--root",
+            str(project_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-configs",
+            "--include-artifacts",
+            "--operation-id",
+            "lifecycle",
+        ]
+    )
+    assert export_without_data["copied_count"] >= 3
+    assert (drive_root / "configs" / "alpha.yml").is_file()
+    assert (drive_root / "artifacts" / "run" / "summary.json").is_file()
+    assert not (drive_root / "configs" / ".env").exists()
+    assert not (drive_root / "configs" / "api_key.txt").exists()
+    assert not (drive_root / "data" / "curated" / "features_daily" / "part-000.csv").exists()
+    assert not (drive_root / "market_data" / "raw_market" / "part-000.csv").exists()
+
+    export_with_data = run_export(
+        [
+            "--root",
+            str(project_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-features",
+            "--include-market-data",
+            "--force",
+            "--operation-id",
+            "lifecycle-data",
+        ]
+    )
+    assert export_with_data["copied_count"] >= 2
+    assert (drive_root / "data" / "curated" / "features_daily" / "part-000.csv").is_file()
+    assert (drive_root / "market_data" / "raw_market" / "part-000.csv").is_file()
+
+    manifest = json.loads(Path(export_with_data["manifest_path"]).read_text())
+    assert manifest["schema_version"] == 1
+    assert manifest["authoritative"] is False
+    assert manifest["operation"] == "export"
+    assert manifest["include_categories"] == ["features", "market_data", "session_metadata"]
+    manifest_order = [(item["category"], item["relative_path"]) for item in manifest["items"]]
+    assert manifest_order == sorted(manifest_order)
+
+    local_config = project_root / "configs" / "alpha.yml"
+    local_config.write_text("local edit\n", encoding="utf-8")
+    no_force_import = run_import(
+        [
+            "--root",
+            str(project_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-configs",
+        ]
+    )
+    assert no_force_import["skipped_count"] >= 1
+    assert local_config.read_text(encoding="utf-8") == "local edit\n"
+
+    force_import = run_import(
+        [
+            "--root",
+            str(project_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-configs",
+            "--force",
+            "--operation-id",
+            "restore",
+        ]
+    )
+    assert force_import["overwritten_count"] >= 1
+    assert local_config.read_text(encoding="utf-8") == "alpha: 1\n"
+
+    after_environ = dict(os.environ)
+    assert after_environ == before_environ
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")

--- a/tests/test_notebook_bootstrap_wheel_smoke.py
+++ b/tests/test_notebook_bootstrap_wheel_smoke.py
@@ -53,9 +53,20 @@ def test_wheel_install_supports_stratlake_init_notebook(tmp_path: Path) -> None:
         assert (workspace_root / relative).is_dir()
 
     assert (workspace_root / "configs" / "features.yml").is_file()
+    assert (workspace_root / "configs" / "session.yml").is_file()
     assert (workspace_root / "configs" / "profiles" / "notebook.yml").is_file()
     assert (workspace_root / "docs" / "notebook_integration.md").is_file()
+    assert (workspace_root / "docs" / "colab_project_sessions.md").is_file()
     assert (workspace_root / "docs" / "examples" / "notebook_execution_api_examples.py").is_file()
+
+    expected_scripts = (
+        "stratlake-init-session",
+        "stratlake-session-export",
+        "stratlake-session-import",
+    )
+    suffix = ".exe" if os.name == "nt" else ""
+    for script in expected_scripts:
+        assert (_venv_scripts_dir(venv_dir) / f"{script}{suffix}").is_file()
 
 
 def _venv_python(venv_dir: Path) -> Path:

--- a/tests/test_notebook_project_session.py
+++ b/tests/test_notebook_project_session.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.session import create_notebook_project_session, write_session_files
+
+
+def test_session_contract_creation_under_explicit_root(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+
+    session = create_notebook_project_session(
+        project_name="stratlake-demo",
+        project_root=project_root,
+        notebook_cwd=tmp_path / "notebook-cwd",
+    )
+
+    assert session.schema_version == 1
+    assert session.project_name == "stratlake-demo"
+    assert session.project_root.path == "."
+    assert session.project_root.source.value == "explicit_root"
+    assert session.configs_root.path == "configs"
+    assert session.artifacts_root.path == "artifacts"
+    assert session.features_root.path == "data/curated"
+    assert session.marketlake_root.path == "data/curated"
+    assert session.notebook_cwd.kind.value == "external_absolute"
+
+
+def test_write_session_files_creates_required_json_files(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    session = create_notebook_project_session(
+        project_name="stratlake-demo",
+        project_root=project_root,
+        notebook_cwd=tmp_path / "notebooks",
+        drive_root=tmp_path / "drive" / "stratlake-demo",
+    )
+
+    result = write_session_files(session)
+
+    assert result.session_path == project_root / ".stratlake" / "session.json"
+    assert result.path_resolution_path == project_root / ".stratlake" / "path_resolution.json"
+    session_json = json.loads(result.session_path.read_text(encoding="utf-8"))
+    assert session_json["schema_version"] == 1
+    assert session_json["project_name"] == "stratlake-demo"
+    assert session_json["project_root"] == {
+        "path": ".",
+        "kind": "project_internal",
+        "source": "explicit_root",
+    }
+    assert session_json["configs_root"]["path"] == "configs"
+    assert session_json["drive_root"]["kind"] == "external_absolute"
+
+
+def test_write_session_files_preserves_existing_user_owned_files_by_default(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    metadata_dir = project_root / ".stratlake"
+    metadata_dir.mkdir(parents=True)
+    session_path = metadata_dir / "session.json"
+    session_path.write_text('{"user_owned": true}\n', encoding="utf-8")
+
+    session = create_notebook_project_session(project_root=project_root)
+
+    with pytest.raises(FileExistsError, match="Refusing to overwrite existing session metadata"):
+        write_session_files(session)
+
+    assert session_path.read_text(encoding="utf-8") == '{"user_owned": true}\n'
+
+
+def test_write_session_files_does_not_create_or_mutate_canonical_artifacts(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    artifacts_root = project_root / "artifacts"
+    artifacts_root.mkdir(parents=True)
+    sentinel = artifacts_root / "sentinel.txt"
+    sentinel.write_text("canonical artifact placeholder\n", encoding="utf-8")
+
+    session = create_notebook_project_session(project_root=project_root)
+    write_session_files(session)
+
+    assert sentinel.read_text(encoding="utf-8") == "canonical artifact placeholder\n"
+    assert not (artifacts_root / "session.json").exists()
+    assert sorted(path.name for path in project_root.iterdir()) == [".stratlake", "artifacts"]
+
+
+def test_notebook_cwd_does_not_affect_output_once_explicit_root_is_provided(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    first_cwd = tmp_path / "first-cwd"
+    second_cwd = tmp_path / "second-cwd"
+    first_cwd.mkdir()
+    second_cwd.mkdir()
+
+    monkeypatch.chdir(first_cwd)
+    first = create_notebook_project_session(
+        project_name="stratlake-demo",
+        project_root=project_root,
+        notebook_cwd=first_cwd,
+    ).to_dict()
+    monkeypatch.chdir(second_cwd)
+    second = create_notebook_project_session(
+        project_name="stratlake-demo",
+        project_root=project_root,
+        notebook_cwd=first_cwd,
+    ).to_dict()
+
+    assert first == second
+
+
+def test_session_writer_rejects_metadata_paths_outside_selected_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "real-root"
+    session = create_notebook_project_session(project_root=project_root)
+    monkeypatch.setattr("src.session.io.SESSION_DIR_NAME", "../outside")
+
+    with pytest.raises(ValueError, match="outside project root"):
+        write_session_files(session)

--- a/tests/test_packaging_readiness.py
+++ b/tests/test_packaging_readiness.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from importlib import metadata
+from importlib import resources
 from pathlib import Path
 import re
 import tomllib
 
+from src.cli.init_notebook_workspace import _resolve_resource_root
 from src.artifacts.safety import portable_path
 
 
@@ -47,6 +49,26 @@ def test_package_version_is_not_milestone_tag_formatted() -> None:
 
 def test_stable_installed_import_smoke() -> None:
     assert portable_path("docs\\manifest.json") == "docs/manifest.json"
+
+
+def test_m42_entry_points_are_declared() -> None:
+    scripts = _load_pyproject()["project"]["scripts"]
+
+    assert scripts["stratlake-init-session"] == "src.cli.init_session:main"
+    assert scripts["stratlake-session-export"] == "src.cli.session_export:main"
+    assert scripts["stratlake-session-import"] == "src.cli.session_import:main"
+
+
+def test_m42_notebook_workspace_resources_are_packaged() -> None:
+    resource_root = _resolve_resource_root()
+
+    assert resource_root.joinpath("configs").joinpath("session.yml").is_file()
+    assert resource_root.joinpath("docs").joinpath("notebook_integration.md").is_file()
+    assert resource_root.joinpath("docs").joinpath("colab_project_sessions.md").is_file()
+
+    package_files = resources.files("src.resources.notebook_workspace")
+    assert package_files.joinpath("configs").joinpath("session.yml").is_file()
+    assert package_files.joinpath("docs").joinpath("colab_project_sessions.md").is_file()
 
 
 def _load_pyproject() -> dict[str, object]:

--- a/tests/test_session_import_export.py
+++ b/tests/test_session_import_export.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.cli.session_export import main as export_main
+from src.cli.session_export import run_cli as run_export_cli
+from src.cli.session_import import main as import_main
+from src.cli.session_import import run_cli as run_import_cli
+from src.session import create_notebook_project_session, write_session_files
+
+
+def _make_session_roots(tmp_path: Path) -> tuple[Path, Path]:
+    local_root = tmp_path / "local-stratlake"
+    drive_root = tmp_path / "drive-root"
+    write_session_files(
+        create_notebook_project_session(
+            project_root=local_root,
+            project_name="demo",
+            drive_root=drive_root,
+            drive_persistence_enabled=True,
+        )
+    )
+    return local_root, drive_root
+
+
+def _write(path: Path, text: str = "content\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_export_cli_returns_useful_summary_and_exit_code(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "alpha.yml")
+
+    exit_code = export_main(
+        [
+            "--root",
+            str(local_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-configs",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "StratLake session export:" in captured.out
+    assert "copied:" in captured.out
+    assert (drive_root / "configs" / "alpha.yml").is_file()
+
+
+def test_export_cli_dry_run_writes_no_files_without_manifest(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "alpha.yml")
+
+    summary = run_export_cli(
+        [
+            "--root",
+            str(local_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-configs",
+            "--dry-run",
+        ]
+    )
+
+    assert summary["dry_run"] is True
+    assert summary["manifest_path"] is None
+    assert not (drive_root / "configs" / "alpha.yml").exists()
+
+
+def test_export_cli_dry_run_manifest_is_marked_dry_run(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "alpha.yml")
+
+    summary = run_export_cli(
+        [
+            "--root",
+            str(local_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-configs",
+            "--dry-run",
+            "--write-manifest",
+            "--operation-id",
+            "dry-run",
+        ]
+    )
+
+    manifest_path = Path(summary["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["dry_run"] is True
+    assert not (drive_root / "configs" / "alpha.yml").exists()
+
+
+def test_import_cli_does_not_overwrite_without_force(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "alpha.yml", "local\n")
+    _write(drive_root / "configs" / "alpha.yml", "drive\n")
+
+    exit_code = import_main(
+        [
+            "--root",
+            str(local_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-configs",
+        ]
+    )
+
+    assert exit_code == 0
+    assert (local_root / "configs" / "alpha.yml").read_text(encoding="utf-8") == "local\n"
+
+
+def test_import_cli_force_overwrites(tmp_path: Path) -> None:
+    local_root, drive_root = _make_session_roots(tmp_path)
+    _write(local_root / "configs" / "alpha.yml", "local\n")
+    _write(drive_root / "configs" / "alpha.yml", "drive\n")
+
+    summary = run_import_cli(
+        [
+            "--root",
+            str(local_root),
+            "--drive-root",
+            str(drive_root),
+            "--include-configs",
+            "--force",
+        ]
+    )
+
+    assert summary["overwritten_count"] >= 1
+    assert (local_root / "configs" / "alpha.yml").read_text(encoding="utf-8") == "drive\n"
+
+
+def test_cli_requires_session_or_reports_clear_error(tmp_path: Path) -> None:
+    exit_code = export_main(["--root", str(tmp_path), "--drive-root", str(tmp_path / "drive")])
+
+    assert exit_code == 2

--- a/tests/test_session_path_resolution.py
+++ b/tests/test_session_path_resolution.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.session import create_notebook_project_session, write_session_files
+
+
+def test_project_internal_paths_serialize_as_posix_relative_paths(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+
+    session = create_notebook_project_session(
+        project_root=project_root,
+        configs_root=Path("configs") / "profiles",
+        artifacts_root=Path("artifacts") / "notebooks" / "run_001",
+        features_root=Path("data") / "curated",
+    )
+
+    assert session.configs_root.path == "configs/profiles"
+    assert session.artifacts_root.path == "artifacts/notebooks/run_001"
+    assert session.features_root.path == "data/curated"
+    assert "\\" not in session.artifacts_root.path
+    assert session.configs_root.kind.value == "project_internal"
+
+
+def test_external_absolute_paths_are_marked_external(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    external_marketlake_root = tmp_path / "external-marketlake" / "curated"
+    external_drive_root = tmp_path / "drive" / "MyDrive" / "stratlake-demo"
+
+    session = create_notebook_project_session(
+        project_root=project_root,
+        marketlake_root=external_marketlake_root,
+        drive_root=external_drive_root,
+    )
+
+    assert session.marketlake_root.path == external_marketlake_root.resolve().as_posix()
+    assert session.marketlake_root.kind.value == "external_absolute"
+    assert session.marketlake_root.source.value == "explicit_marketlake_root"
+    assert session.drive_root is not None
+    assert session.drive_root.path == external_drive_root.resolve().as_posix()
+    assert session.drive_root.kind.value == "external_absolute"
+    assert session.drive_root.source.value == "explicit_drive_root"
+
+
+def test_project_relative_paths_that_escape_root_keep_their_relative_text(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "workspace" / "stratlake-demo"
+
+    session = create_notebook_project_session(
+        project_root=project_root,
+        marketlake_root="../fintech/data/curated",
+    )
+
+    assert session.marketlake_root.path == "../fintech/data/curated"
+    assert session.marketlake_root.kind.value == "external_or_project_relative"
+    assert session.marketlake_root.resolved_path.endswith("/workspace/fintech/data/curated")
+
+
+def test_path_resolution_report_contains_readable_provenance(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    notebook_cwd = tmp_path / "cloud-notebook-root"
+    external_marketlake_root = tmp_path / "marketlake" / "data" / "curated"
+
+    session = create_notebook_project_session(
+        project_name="stratlake-demo",
+        project_root=project_root,
+        notebook_cwd=notebook_cwd,
+        marketlake_root=external_marketlake_root,
+    )
+    result = write_session_files(session)
+
+    report = json.loads(result.path_resolution_path.read_text(encoding="utf-8"))
+    assert report["schema_version"] == 1
+    assert report["project_name"] == "stratlake-demo"
+    assert report["paths"]["notebook_cwd"]["source"] == "current_working_directory"
+    assert report["paths"]["notebook_cwd"]["resolved_path"] == notebook_cwd.resolve().as_posix()
+    assert report["paths"]["project_root"]["path"] == "."
+    assert report["paths"]["configs_root"]["base"] == project_root.resolve().as_posix()
+    assert report["paths"]["marketlake_root"]["kind"] == "external_absolute"
+    assert report["paths"]["marketlake_root"]["input_path"] == str(external_marketlake_root)

--- a/tests/test_session_path_resolution.py
+++ b/tests/test_session_path_resolution.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
-from src.session import create_notebook_project_session, write_session_files
+import pytest
+
+from src.session import (
+    create_notebook_project_session,
+    find_session_root,
+    load_session,
+    resolve_session_paths,
+    write_path_resolution_report,
+    write_session_files,
+)
 
 
 def test_project_internal_paths_serialize_as_posix_relative_paths(tmp_path: Path) -> None:
@@ -80,3 +90,194 @@ def test_path_resolution_report_contains_readable_provenance(tmp_path: Path) -> 
     assert report["paths"]["configs_root"]["base"] == project_root.resolve().as_posix()
     assert report["paths"]["marketlake_root"]["kind"] == "external_absolute"
     assert report["paths"]["marketlake_root"]["input_path"] == str(external_marketlake_root)
+
+
+def test_find_session_root_finds_session_from_nested_directory(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    nested = project_root / "notebooks" / "experiments"
+    nested.mkdir(parents=True)
+    write_session_files(create_notebook_project_session(project_root=project_root))
+
+    assert find_session_root(nested) == project_root.resolve()
+
+
+def test_find_session_root_fails_clearly_when_no_session_exists(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="No StratLake session root found"):
+        find_session_root(tmp_path)
+
+
+def test_load_session_loads_valid_session_written_by_writer(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    write_session_files(
+        create_notebook_project_session(
+            project_root=project_root,
+            project_name="demo",
+            marketlake_root="../marketlake/data/curated",
+        )
+    )
+
+    session = load_session(project_root / "notebooks")
+
+    assert session.project_name == "demo"
+    assert session.project_root.resolved_path == project_root.resolve().as_posix()
+    assert session.marketlake_root.path == "../marketlake/data/curated"
+    assert session.marketlake_root.kind.value == "external_or_project_relative"
+
+
+def test_load_session_fails_for_missing_session_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="No StratLake session root found"):
+        load_session(tmp_path)
+
+
+def test_load_session_fails_for_invalid_json(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    session_path = project_root / ".stratlake" / "session.json"
+    session_path.parent.mkdir(parents=True)
+    session_path.write_text("{not-json\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid StratLake session JSON"):
+        load_session(project_root)
+
+
+def test_load_session_fails_for_unsupported_schema_version(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    write_session_files(create_notebook_project_session(project_root=project_root))
+    session_path = project_root / ".stratlake" / "session.json"
+    payload = json.loads(session_path.read_text(encoding="utf-8"))
+    payload["schema_version"] = 999
+    session_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported StratLake session schema version"):
+        load_session(project_root)
+
+
+def test_resolve_session_paths_uses_explicit_root_without_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    other_cwd = tmp_path / "other-cwd"
+    other_cwd.mkdir()
+    write_session_files(create_notebook_project_session(project_root=project_root))
+    monkeypatch.chdir(other_cwd)
+
+    paths = resolve_session_paths(project_root)
+
+    assert paths["project_root"].resolved_path == project_root.resolve().as_posix()
+    assert paths["configs_root"].resolved_path == (project_root / "configs").resolve().as_posix()
+    assert not (other_cwd / ".stratlake").exists()
+
+
+def test_explicit_overrides_win_over_session_metadata(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    external_marketlake = tmp_path / "external" / "curated"
+    write_session_files(create_notebook_project_session(project_root=project_root))
+
+    paths = resolve_session_paths(
+        project_root,
+        overrides={
+            "marketlake_root": external_marketlake,
+            "artifacts_root": "artifacts/session-demo",
+        },
+    )
+
+    assert paths["marketlake_root"].path == external_marketlake.resolve().as_posix()
+    assert paths["marketlake_root"].kind.value == "external_absolute"
+    assert paths["marketlake_root"].source.value == "explicit_override"
+    assert paths["artifacts_root"].path == "artifacts/session-demo"
+    assert paths["artifacts_root"].source.value == "explicit_override"
+
+
+def test_environment_fallback_records_provenance_for_partial_session_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    session = create_notebook_project_session(project_root=project_root)
+    partial_payload = session.to_dict()
+    partial_payload["project_root"] = {
+        **partial_payload["project_root"],
+        "resolved_path": project_root.resolve().as_posix(),
+    }
+    partial_payload["marketlake_root"] = {
+        "path": "",
+        "kind": "project_internal",
+        "source": "default",
+    }
+    external_marketlake = tmp_path / "env-marketlake" / "curated"
+    before = dict(os.environ)
+    monkeypatch.setenv("MARKETLAKE_ROOT", str(external_marketlake))
+
+    paths = resolve_session_paths(partial_payload)
+
+    assert paths["marketlake_root"].path == external_marketlake.resolve().as_posix()
+    assert paths["marketlake_root"].source.value == "environment_variable"
+    assert paths["marketlake_root"].input_path == f"MARKETLAKE_ROOT={external_marketlake}"
+    after = dict(os.environ)
+    after.pop("MARKETLAKE_ROOT", None)
+    assert after == before
+
+
+def test_resolve_session_paths_preserves_portable_and_external_classification(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "workspace" / "stratlake-demo"
+    write_session_files(
+        create_notebook_project_session(
+            project_root=project_root,
+            configs_root="configs/profiles",
+            marketlake_root="../marketlake/data/curated",
+            drive_root=tmp_path / "drive" / "MyDrive" / "stratlake-demo",
+        )
+    )
+
+    paths = resolve_session_paths(project_root)
+
+    assert paths["configs_root"].path == "configs/profiles"
+    assert "\\" not in paths["configs_root"].path
+    assert paths["configs_root"].kind.value == "project_internal"
+    assert paths["marketlake_root"].path == "../marketlake/data/curated"
+    assert paths["marketlake_root"].kind.value == "external_or_project_relative"
+    assert paths["drive_root"].kind.value == "external_absolute"
+
+
+def test_write_path_resolution_report_writes_deterministic_json(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    write_session_files(create_notebook_project_session(project_root=project_root))
+
+    report_path = write_path_resolution_report(
+        project_root,
+        overrides={"artifacts_root": "artifacts/notebook-demo"},
+    )
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report_path == project_root / ".stratlake" / "path_resolution.json"
+    assert report["paths"]["artifacts_root"]["path"] == "artifacts/notebook-demo"
+    assert report["paths"]["artifacts_root"]["source"] == "explicit_override"
+    assert report_path.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_write_path_resolution_report_refuses_unsafe_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    write_session_files(create_notebook_project_session(project_root=project_root))
+    session = load_session(project_root)
+    monkeypatch.setattr("src.session.paths.SESSION_DIR_NAME", "../outside")
+
+    with pytest.raises(ValueError, match="outside project root"):
+        write_path_resolution_report(session)
+
+
+def test_path_helpers_do_not_mutate_canonical_artifacts(tmp_path: Path) -> None:
+    project_root = tmp_path / "stratlake-demo"
+    artifact = project_root / "artifacts" / "canonical.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("canonical artifact\n", encoding="utf-8")
+    write_session_files(create_notebook_project_session(project_root=project_root))
+
+    resolve_session_paths(project_root)
+    write_path_resolution_report(project_root)
+
+    assert artifact.read_text(encoding="utf-8") == "canonical artifact\n"


### PR DESCRIPTION
## Summary

This PR implements M42 — Notebook Project Sessions and Filesystem Drive Persistence.

M42 adds a deterministic notebook project-session layer for StratLake workflows, improving notebook and Colab ergonomics when the notebook CWD, StratLake project root, external MarketLake root, and mounted Drive persistence root differ.

The milestone adds session metadata, session-aware path helpers, a session-first bootstrap command, filesystem-only mounted Drive import/export, Colab documentation, and final release-readiness validation while preserving StratLake’s artifact-first architecture.

## Major Changes

- Added notebook project-session contract under `src/session/`.
- Added `.stratlake/session.json` and `.stratlake/path_resolution.json` session metadata.
- Added copied starter template `configs/session.yml`.
- Added `stratlake-init-session` for session-first notebook bootstrap.
- Added session-aware path helpers:
  - `find_session_root`
  - `load_session`
  - `resolve_session_paths`
  - `write_path_resolution_report`
- Added filesystem-only persistence helpers and CLI commands:
  - `stratlake-session-export`
  - `stratlake-session-import`
- Added deterministic copy manifests under `artifacts/_derived/notebook_sessions/...`.
- Added safe default excludes for session persistence snapshots.
- Added explicit gates for feature and market-data persistence:
  - `--include-features`
  - `--include-market-data`
- Added Colab project-session documentation and copied workspace resource docs.
- Added M42 release notes and release validation checklist.
- Added focused deterministic validation for the full M42 lifecycle.

## Architecture Boundaries Preserved

M42 does not introduce:

- Google Drive API integration
- OAuth
- network access
- background sync
- remote registry
- remote metadata service
- credential workflow
- live market data dependency
- hidden CWD mutation
- `.env` or `os.environ` mutation
- a second source of truth

Session files, Drive copies, and Drive manifests are diagnostic/non-authoritative. Canonical research evidence remains in StratLake artifacts, manifests, metrics, summaries, inventories, and named workflow outputs.

## Validation

Passed locally:

- `ruff check src/session src/cli tests`
- Focused M42 validation slice: `65 passed, 1 skipped`
- Docs/path portability slice: `18 passed`
- Full `pytest`: `2301 passed, 5 skipped`
- `python -m build` passed

Notes:

- `tests/test_docs_path_lint.py` is not present in this checkout, so existing docs/path portability coverage was used instead.
- `tests/test_notebook_bootstrap_wheel_smoke.py` remains opt-in unless `STRATLAKE_RUN_NOTEBOOK_BOOTSTRAP_WHEEL_SMOKE=1`.
- `python -m build` still emits the existing setuptools license-table deprecation warning; this is non-blocking and not introduced by M42.

## Issues

Closes #456  
Closes #457  
Closes #458  
Closes #459  
Closes #460  
Closes #461

## Release Tag Candidate

`v0.42.0-notebook-project-sessions-drive-persistence`