### PR TITLE
M42.7 — Update Version and Release Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Start with:
 
 * [docs/notebook_integration.md](docs/notebook_integration.md)
 * [docs/notebook_workspace_bootstrap.md](docs/notebook_workspace_bootstrap.md)
+* [docs/colab_project_sessions.md](docs/colab_project_sessions.md)
 * [docs/notebook_execution_api.md](docs/notebook_execution_api.md)
 * [docs/pipeline_integration.md](docs/pipeline_integration.md)
 * [docs/concurrency_and_idempotency.md](docs/concurrency_and_idempotency.md)
@@ -594,6 +595,56 @@ Start with:
 
 * [docs/m41_release_notes.md](docs/m41_release_notes.md)
 * [docs/getting_started.md](docs/getting_started.md)
+* [docs/notebook_integration.md](docs/notebook_integration.md)
+* [docs/notebook_workspace_bootstrap.md](docs/notebook_workspace_bootstrap.md)
+
+### Release 0.42.0: Notebook Project Sessions and Filesystem Drive Persistence
+
+Release 0.42.0 aligns the package metadata and release-facing docs with the
+M42 notebook project-session milestone. Notebook and Colab-style workflows can
+initialize an explicit StratLake project session, inspect resolved paths with
+provenance, and optionally export or import selected session content through a
+filesystem-only mounted Drive path.
+
+Session bootstrap:
+
+```bash
+stratlake-init-session --root ./stratlake-workspace --project-name stratlake-demo
+```
+
+Session path inspection:
+
+```python
+from src.session import load_session, resolve_session_paths
+
+session = load_session("./stratlake-workspace")
+paths = resolve_session_paths(session)
+```
+
+Filesystem-only persistence snapshots:
+
+```bash
+stratlake-session-export --root ./stratlake-workspace --drive-root ./mounted-drive/stratlake-demo --include-configs --include-artifacts
+stratlake-session-import --root ./stratlake-workspace --drive-root ./mounted-drive/stratlake-demo --include-configs
+```
+
+Drive persistence is optional and treats the Drive root as a normal mounted
+filesystem path. StratLake does not use Google APIs, OAuth, credentials,
+network access, background sync, a remote registry, or a second source of truth.
+Session files and Drive manifests are diagnostic and non-authoritative;
+canonical artifacts remain the authoritative research evidence.
+
+Package/build version:
+`0.42.0`
+
+Release tag:
+`v0.42.0-notebook-project-sessions-drive-persistence`
+
+Start with:
+
+* [docs/m42_release_notes.md](docs/m42_release_notes.md)
+* [docs/m42_release_validation_checklist.md](docs/m42_release_validation_checklist.md)
+* [docs/colab_project_sessions.md](docs/colab_project_sessions.md)
 * [docs/notebook_integration.md](docs/notebook_integration.md)
 * [docs/notebook_workspace_bootstrap.md](docs/notebook_workspace_bootstrap.md)
 

--- a/docs/m42_release_notes.md
+++ b/docs/m42_release_notes.md
@@ -4,10 +4,13 @@ Milestone title:
 `M42 - Notebook Project Sessions and Filesystem Drive Persistence`
 
 M42 branch:
-`feature/m42-notebook-project-sessions-drive-persistence`
+`release/m42-version-tag-update`
 
 Candidate milestone release tag:
 `v0.42.0-notebook-project-sessions-drive-persistence`
+
+Package/build version:
+`0.42.0`
 
 ## Milestone Principle
 
@@ -156,7 +159,7 @@ Tag:
 `v0.42.0-notebook-project-sessions-drive-persistence`
 
 Branch:
-`feature/m42-notebook-project-sessions-drive-persistence`
+`release/m42-version-tag-update`
 
 Summary:
 M42 adds deterministic notebook project sessions for StratLake workflows.

--- a/docs/m42_release_validation_checklist.md
+++ b/docs/m42_release_validation_checklist.md
@@ -7,10 +7,13 @@ Milestone title:
 `M42 - Notebook Project Sessions and Filesystem Drive Persistence`
 
 M42 branch:
-`feature/m42-notebook-project-sessions-drive-persistence`
+`release/m42-version-tag-update`
 
 Candidate milestone release tag:
 `v0.42.0-notebook-project-sessions-drive-persistence`
+
+Package/build version:
+`0.42.0`
 
 ## M42 Scope Recap
 
@@ -161,6 +164,10 @@ Confirm installed entry points include:
 * `stratlake-init-session`
 * `stratlake-session-export`
 * `stratlake-session-import`
+
+Confirm package/build version metadata reports:
+
+* `0.42.0`
 
 If the build emits the existing setuptools license-table deprecation warning,
 record it as existing and non-blocking unless this branch changes packaging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stratlake-trade-engine"
-version = "0.41.0"
+version = "0.42.0"
 description = "Deterministic, artifact-driven quantitative research and backtesting platform."
 authors = [{ name = "Christopher Overton" }]
 readme = "README.md"

--- a/tests/test_packaging_readiness.py
+++ b/tests/test_packaging_readiness.py
@@ -47,6 +47,22 @@ def test_package_version_is_not_milestone_tag_formatted() -> None:
     assert not re.match(r"^v\d+\.\d+\.\d+(?:-|$)", declared_version)
 
 
+def test_m42_release_version_and_tag_metadata_are_consistent() -> None:
+    declared_version = _declared_project_version()
+    expected_version = "0.42.0"
+    expected_tag = "v0.42.0-notebook-project-sessions-drive-persistence"
+
+    assert declared_version == expected_version
+    for path in (
+        REPO_ROOT / "README.md",
+        REPO_ROOT / "docs" / "m42_release_notes.md",
+        REPO_ROOT / "docs" / "m42_release_validation_checklist.md",
+    ):
+        text = path.read_text(encoding="utf-8")
+        assert expected_version in text
+        assert expected_tag in text
+
+
 def test_stable_installed_import_smoke() -> None:
     assert portable_path("docs\\manifest.json") == "docs/manifest.json"
 

--- a/tests/test_packaging_readiness.py
+++ b/tests/test_packaging_readiness.py
@@ -51,6 +51,10 @@ def test_m42_release_version_and_tag_metadata_are_consistent() -> None:
     declared_version = _declared_project_version()
     expected_version = "0.42.0"
     expected_tag = "v0.42.0-notebook-project-sessions-drive-persistence"
+    version_pattern = re.compile(
+        rf"Package/build version:\s*\n`{re.escape(expected_version)}`",
+        re.MULTILINE,
+    )
 
     assert declared_version == expected_version
     for path in (
@@ -59,7 +63,7 @@ def test_m42_release_version_and_tag_metadata_are_consistent() -> None:
         REPO_ROOT / "docs" / "m42_release_validation_checklist.md",
     ):
         text = path.read_text(encoding="utf-8")
-        assert expected_version in text
+        assert version_pattern.search(text)
         assert expected_tag in text
 
 


### PR DESCRIPTION
## Summary

This PR completes M42.7 release metadata alignment for the M42 notebook project-session milestone.

It updates the package/build version to `0.42.0`, aligns release-tag metadata across M42 release docs, updates README release references, and adds consistency coverage to keep package version and milestone release tag semantics distinct.

## Changes

- Updated `pyproject.toml` package/build version:
  - `0.41.0` → `0.42.0`
- Added focused README release documentation for:
  - Release `0.42.0`
  - M42 notebook project sessions
  - filesystem-only Drive persistence snapshots
  - M42 release tag
  - Colab/session documentation references
- Updated `docs/m42_release_notes.md` with:
  - release branch metadata
  - package/build version
  - candidate release tag
- Updated `docs/m42_release_validation_checklist.md` with:
  - release branch metadata
  - package/build version
  - package-version validation guidance
- Updated `tests/test_packaging_readiness.py` with version/tag consistency coverage.

## Version / Tag Metadata

Package/build version:

```text
0.42.0