### PR TITLE
Fix portfolio CLI entrypoint and M11 workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1935,7 +1935,7 @@ python -m src.cli.run_portfolio --portfolio-config configs/portfolios.yml --port
 Walk-forward portfolio evaluation:
 
 ```powershell
-python -m src.cli.run_portfolio --portfolio-config configs/portfolios.yml --portfolio-name strict_valid_builtin_pair --from-registry --evaluation configs/evaluation.yml --timeframe 1D --strict
+python -m src.cli.run_portfolio --portfolio-config configs/portfolios.yml --portfolio-name strict_valid_builtin_pair --from-registry --evaluation configs/evaluation_portfolio_2026_q1.yml --timeframe 1D --strict
 ```
 
 The end-to-end Milestone 11 guide, including config snippets and output

--- a/configs/evaluation_portfolio_2026_q1.yml
+++ b/configs/evaluation_portfolio_2026_q1.yml
@@ -1,0 +1,8 @@
+evaluation:
+  mode: rolling
+  timeframe: "1d"
+  start: "2026-01-01"
+  end: "2026-04-03"
+  train_window: 6W
+  test_window: 2W
+  step: 2W

--- a/configs/simulation_portfolio_example.yml
+++ b/configs/simulation_portfolio_example.yml
@@ -1,0 +1,6 @@
+simulation:
+  method: bootstrap
+  num_paths: 500
+  path_length: 252
+  seed: 7
+  drawdown_threshold: 0.20

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -295,7 +295,7 @@ python -m src.cli.run_portfolio --portfolio-config configs/portfolios.yml --port
 Strict walk-forward example:
 
 ```powershell
-python -m src.cli.run_portfolio --portfolio-config configs/portfolios.yml --portfolio-name strict_valid_builtin_pair --from-registry --evaluation configs/evaluation.yml --timeframe 1D --strict
+python -m src.cli.run_portfolio --portfolio-config configs/portfolios.yml --portfolio-name strict_valid_builtin_pair --from-registry --evaluation configs/evaluation_portfolio_2026_q1.yml --timeframe 1D --strict
 ```
 
 Portfolio artifacts are written under `artifacts/portfolios/<run_id>/`.

--- a/docs/milestone_11_portfolio_workflow.md
+++ b/docs/milestone_11_portfolio_workflow.md
@@ -433,10 +433,8 @@ It is not available with:
 
 ### Portfolio CLI example
 
-The repository does not currently ship a `configs/simulation.yml`, so create
-your own config file and point the CLI at it.
-
-Example simulation config:
+The repository ships a reproducible example at
+[../configs/simulation_portfolio_example.yml](../configs/simulation_portfolio_example.yml):
 
 ```yaml
 simulation:
@@ -455,7 +453,7 @@ python -m src.cli.run_portfolio \
   --portfolio-name momentum_meanrev_equal \
   --from-registry \
   --timeframe 1D \
-  --simulation path/to/simulation.yml
+  --simulation configs/simulation_portfolio_example.yml
 ```
 
 ### How to interpret simulation outputs
@@ -535,9 +533,16 @@ python -m src.cli.run_portfolio \
   --portfolio-config configs/portfolios.yml \
   --portfolio-name strict_valid_builtin_pair \
   --from-registry \
-  --evaluation configs/evaluation.yml \
+  --evaluation configs/evaluation_portfolio_2026_q1.yml \
   --timeframe 1D
 ```
+
+The example config [../configs/evaluation_portfolio_2026_q1.yml](../configs/evaluation_portfolio_2026_q1.yml)
+uses a 2026 Q1 rolling window that overlaps the strategy artifacts produced by
+the prerequisite `momentum_v1` and `mean_reversion_v1` runs. The general
+strategy evaluation config, `configs/evaluation.yml`, starts at `2022-01-01`
+and is not suitable for this portfolio example unless your component strategy
+artifacts include returns for the initial train window.
 
 Current behavior:
 

--- a/docs/portfolio_configuration.md
+++ b/docs/portfolio_configuration.md
@@ -412,7 +412,7 @@ python -m src.cli.run_portfolio \
   --portfolio-config configs/portfolios.yml \
   --portfolio-name strict_valid_builtin_pair \
   --from-registry \
-  --evaluation configs/evaluation.yml \
+  --evaluation configs/evaluation_portfolio_2026_q1.yml \
   --timeframe 1D
 ```
 
@@ -420,6 +420,9 @@ In walk-forward mode:
 
 * the portfolio config still defines components and allocator
 * the evaluation config defines the splits
+* the shipped portfolio example uses `configs/evaluation_portfolio_2026_q1.yml`
+  so the splits overlap the prerequisite `momentum_v1` and
+  `mean_reversion_v1` artifacts
 * the portfolio timeframe must match the evaluation timeframe
 * simulation cannot be combined with `--evaluation`
 

--- a/docs/portfolio_construction_workflow.md
+++ b/docs/portfolio_construction_workflow.md
@@ -312,7 +312,7 @@ python -m src.cli.run_portfolio \
   --portfolio-name momentum_meanrev_equal \
   --from-registry \
   --timeframe 1D \
-  --simulation path/to/simulation.yml
+  --simulation configs/simulation_portfolio_example.yml
 ```
 
 Walk-forward portfolio:
@@ -322,7 +322,7 @@ python -m src.cli.run_portfolio \
   --portfolio-config configs/portfolios.yml \
   --portfolio-name strict_valid_builtin_pair \
   --from-registry \
-  --evaluation configs/evaluation.yml \
+  --evaluation configs/evaluation_portfolio_2026_q1.yml \
   --timeframe 1D
 ```
 

--- a/src/cli/run_portfolio.py
+++ b/src/cli/run_portfolio.py
@@ -620,7 +620,7 @@ def main() -> None:
     """CLI entrypoint used by direct module execution."""
 
     try:
-        run_cli()
+        run_cli(sys.argv[1:])
     except (ResearchStrictModeError, ValueError) as exc:
         print(_format_run_failure(exc), file=sys.stderr)
         raise SystemExit(1) from exc

--- a/tests/test_cli_run_portfolio.py
+++ b/tests/test_cli_run_portfolio.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from src.cli.run_portfolio import (
     PortfolioRunResult,
     PortfolioWalkForwardRunResult,
+    main,
     parse_args,
     parse_run_ids,
     run_cli,
@@ -127,6 +128,90 @@ def test_parse_run_ids_supports_mixed_cli_formats() -> None:
         "run-c",
         "run-d",
     ]
+
+
+def test_main_forwards_sys_argv_to_portfolio_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, list[str]] = {}
+
+    def fake_run_cli(argv):
+        captured["argv"] = list(argv)
+
+    monkeypatch.setattr("src.cli.run_portfolio.run_cli", fake_run_cli)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "python -m src.cli.run_portfolio",
+            "--portfolio-name",
+            "core_portfolio",
+            "--run-ids",
+            "run-alpha",
+            "--timeframe",
+            "1D",
+        ],
+    )
+
+    main()
+
+    assert captured["argv"] == [
+        "--portfolio-name",
+        "core_portfolio",
+        "--run-ids",
+        "run-alpha",
+        "--timeframe",
+        "1D",
+    ]
+
+
+def test_run_cli_installed_script_equivalent_path_preserves_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_portfolio_resolved(**kwargs):
+        captured.update(kwargs)
+        return PortfolioRunResult(
+            portfolio_name=str(kwargs["portfolio_name"]),
+            run_id="core_portfolio_abc123",
+            allocator_name="equal_weight",
+            timeframe=str(kwargs["timeframe"]),
+            component_count=1,
+            metrics={
+                "total_return": 0.0,
+                "gross_total_return": 0.0,
+                "execution_drag_total_return": 0.0,
+                "total_execution_friction": 0.0,
+                "sharpe_ratio": 0.0,
+                "realized_volatility": 0.0,
+                "max_drawdown": 0.0,
+                "value_at_risk": 0.0,
+                "conditional_value_at_risk": 0.0,
+            },
+            experiment_dir=Path("artifacts/portfolios/core_portfolio_abc123"),
+            portfolio_output=pd.DataFrame(),
+            config={"allocator": "equal_weight"},
+            components=[{"strategy_name": "alpha_v1", "run_id": "run-alpha"}],
+        )
+
+    monkeypatch.setattr("src.execution.portfolio._run_portfolio_resolved", fake_run_portfolio_resolved)
+
+    result = run_cli(
+        [
+            "--portfolio-name",
+            "core_portfolio",
+            "--run-ids",
+            "run-alpha",
+            "--timeframe",
+            "1D",
+        ]
+    )
+
+    assert isinstance(result, PortfolioRunResult)
+    assert captured["portfolio_name"] == "core_portfolio"
+    assert captured["explicit_run_ids"] == ["run-alpha"]
+    assert captured["timeframe"] == "1D"
 
 
 def test_run_cli_builds_portfolio_from_explicit_run_ids(
@@ -1222,6 +1307,75 @@ def test_run_cli_strict_portfolio_config_from_registry_succeeds_and_persists_aud
         "enabled": True,
         "source": "cli",
     }
+
+
+def test_run_cli_documented_portfolio_walk_forward_config_overlaps_strategy_data(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    strategy_root = tmp_path / "artifacts" / "strategies"
+    portfolio_root = tmp_path / "artifacts" / "portfolios"
+    repo_root = Path(__file__).resolve().parents[1]
+    portfolio_config_path = repo_root / "configs" / "portfolios.yml"
+    evaluation_path = repo_root / "configs" / "evaluation_portfolio_2026_q1.yml"
+    rows = [
+        {
+            "ts_utc": timestamp.strftime("%Y-%m-%dT00:00:00Z"),
+            "strategy_return": 0.004 if index % 2 == 0 else -0.002,
+        }
+        for index, timestamp in enumerate(pd.date_range("2026-01-01", "2026-04-02", freq="D"))
+    ]
+    mean_reversion_rows = [
+        {
+            "ts_utc": row["ts_utc"],
+            "strategy_return": -0.001 if index % 2 == 0 else 0.003,
+        }
+        for index, row in enumerate(rows)
+    ]
+
+    _write_registered_strategy_run(
+        strategy_root,
+        run_id="run-momentum",
+        strategy_name="momentum_v1",
+        rows=rows,
+        timeframe="1D",
+        timestamp="2026-03-25T00:00:00Z",
+    )
+    _write_registered_strategy_run(
+        strategy_root,
+        run_id="run-meanrev",
+        strategy_name="mean_reversion_v1",
+        rows=mean_reversion_rows,
+        timeframe="1D",
+        timestamp="2026-03-25T00:05:00Z",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("src.cli.run_portfolio.experiment_tracker.ARTIFACTS_ROOT", strategy_root)
+    monkeypatch.setattr("src.portfolio.walk_forward.experiment_tracker.ARTIFACTS_ROOT", strategy_root)
+    monkeypatch.setattr("src.cli.run_portfolio.DEFAULT_PORTFOLIO_ARTIFACTS_ROOT", portfolio_root)
+
+    result = run_cli(
+        [
+            "--portfolio-config",
+            str(portfolio_config_path),
+            "--portfolio-name",
+            "strict_valid_builtin_pair",
+            "--from-registry",
+            "--evaluation",
+            str(evaluation_path),
+            "--timeframe",
+            "1D",
+        ]
+    )
+
+    assert isinstance(result, PortfolioWalkForwardRunResult)
+    assert result.split_count > 0
+    assert result.experiment_dir == portfolio_root / result.run_id
+    assert (result.experiment_dir / "aggregate_metrics.json").exists()
+    metrics_by_split = pd.read_csv(result.experiment_dir / "metrics_by_split.csv")
+    assert metrics_by_split["split_id"].tolist()[0] == "rolling_0000"
+    assert metrics_by_split["row_count"].min() > 0
 
 
 def test_run_cli_writes_portfolio_simulation_artifacts(


### PR DESCRIPTION
## Summary

Fixes issue #501 by making the documented Milestone 11 portfolio workflow executable as written and by replacing non-reproducible/failing portfolio examples with concrete configs.

## Changes

- Fix `src/cli/run_portfolio.py` so `main()` forwards `sys.argv[1:]` into `run_cli(...)`.
- Add `configs/evaluation_portfolio_2026_q1.yml` for the documented portfolio walk-forward example.
- Add `configs/simulation_portfolio_example.yml` so simulation docs reference a real reproducible config path.
- Update Milestone 11, getting started, portfolio construction/configuration docs, and README references.
- Add regression tests for:
  - module-entrypoint argv forwarding
  - installed-script-equivalent `run_cli([...])`
  - corrected walk-forward config overlap with strategy data

## Verification

- `\.\.venv\Scripts\python.exe -m pytest tests\test_cli_run_portfolio.py -q` → `22 passed`
- `\.\.venv\Scripts\ruff.exe check src\cli\run_portfolio.py tests\test_cli_run_portfolio.py` → passed
- Verified `python -m src.cli.run_portfolio --help`
- Verified `\.\.venv\Scripts\stratlake-run-portfolio.exe --help`
- Ran documented strategy prerequisites and portfolio variants in an isolated `C:\tmp` verification workspace, including baseline, console script, optimizer, risk, execution friction, simulation, and corrected walk-forward commands.

## Notes

- The pre-existing untracked `.claude/` directory was left untouched.
- Follow-up suggestion from audit: consider normalizing `configs/evaluation_portfolio_2026_q1.yml` timeframe from `"1d"` to `"1D"` for readability if the loader does not intentionally document lowercase values.

Refs #501