### PR TITLE
Polish portfolio workflow version and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ status vocabulary, registry-backed review canonical evidence requirements,
 artifact filename security, and boundary-hardened governance validation.
 
 Package/build version:
-`0.45.0`
+`0.45.1`
 
 Release tag:
 `v0.45.0`

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Start with:
 * [docs/examples/notebook_execution_api_examples.py](docs/examples/notebook_execution_api_examples.py)
 * [docs/examples/ml_cross_sectional_xgb_2026_q1_notebook.ipynb](docs/examples/ml_cross_sectional_xgb_2026_q1_notebook.ipynb)
 
-### Release 0.45.0: Canonical Promotion-State Contracts
+### Release 0.45.1: Canonical Promotion-State Contracts
 
-Release 0.45.0 completes M45 canonical promotion-state contracts and governance
+Release 0.45.1 completes M45 canonical promotion-state contracts and governance
 validation. It establishes deterministic, engine-owned promotion-state evidence
 for standalone research reviews and campaign containers, bounded compatibility
 status vocabulary, registry-backed review canonical evidence requirements,
@@ -58,7 +58,7 @@ Package/build version:
 `0.45.1`
 
 Release tag:
-`v0.45.0`
+`v0.45.1`
 
 Start with:
 

--- a/configs/evaluation_portfolio_2026_q1.yml
+++ b/configs/evaluation_portfolio_2026_q1.yml
@@ -1,6 +1,6 @@
 evaluation:
   mode: rolling
-  timeframe: "1d"
+  timeframe: "1D"
   start: "2026-01-01"
   end: "2026-04-03"
   train_window: 6W

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stratlake-trade-engine"
-version = "0.45.0"
+version = "0.45.1"
 description = "Deterministic, artifact-driven quantitative research and backtesting platform."
 authors = [{ name = "Christopher Overton" }]
 readme = "README.md"

--- a/tests/test_packaging_readiness.py
+++ b/tests/test_packaging_readiness.py
@@ -58,7 +58,11 @@ def test_release_version_metadata_is_consistent() -> None:
     assert declared_version == expected_version
     readme_text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     assert version_pattern.search(readme_text)
-    assert "v0.45.0" in readme_text
+    release_tag_pattern = re.compile(
+        r"Release tag:\s*\n`v0\.45\.1`",
+        re.MULTILINE,
+    )
+    assert release_tag_pattern.search(readme_text)
 
     m44_version_pattern = re.compile(
         r"Package/build version:\s*\n`0\.45\.0`",

--- a/tests/test_packaging_readiness.py
+++ b/tests/test_packaging_readiness.py
@@ -49,7 +49,7 @@ def test_package_version_is_not_milestone_tag_formatted() -> None:
 
 def test_release_version_metadata_is_consistent() -> None:
     declared_version = _declared_project_version()
-    expected_version = "0.45.0"
+    expected_version = "0.45.1"
     version_pattern = re.compile(
         rf"Package/build version:\s*\n`{re.escape(expected_version)}`",
         re.MULTILINE,
@@ -58,15 +58,19 @@ def test_release_version_metadata_is_consistent() -> None:
     assert declared_version == expected_version
     readme_text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     assert version_pattern.search(readme_text)
-    assert f"v{expected_version}" in readme_text
+    assert "v0.45.0" in readme_text
 
+    m44_version_pattern = re.compile(
+        r"Package/build version:\s*\n`0\.45\.0`",
+        re.MULTILINE,
+    )
     m44_tag = "v0.45.0-colab-notebook-session-ergonomics-marketlake-handoff"
     for path in (
         REPO_ROOT / "docs" / "m44_release_notes.md",
         REPO_ROOT / "docs" / "m44_release_validation_checklist.md",
     ):
         text = path.read_text(encoding="utf-8")
-        assert version_pattern.search(text)
+        assert m44_version_pattern.search(text)
         assert m44_tag in text
 
 


### PR DESCRIPTION
This pull request updates the project version from `0.45.0` to `0.45.1` across the codebase and ensures consistency in version metadata and configuration. It also corrects a minor formatting issue in an evaluation configuration file. These changes are primarily focused on release management and metadata accuracy.

Version update and consistency:

* Updated the project version to `0.45.1` in `pyproject.toml`, `README.md`, and the version metadata test to ensure consistency across the project. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58) [[3]](diffhunk://#diff-3ce96ec38db842b11beebfb9ec181633f2078cc85a731a28b69247b8bf8d6543L52-R52)
* Modified the release version metadata test to check for the new version and added a separate check for legacy documentation referencing `0.45.0`.

Configuration fix:

* Corrected the `timeframe` value in `configs/evaluation_portfolio_2026_q1.yml` from `"1d"` to `"1D"` for consistency with expected format.Refs #501

